### PR TITLE
geom_alt props

### DIFF
--- a/data/421/166/429/421166429.geojson
+++ b/data/421/166/429/421166429.geojson
@@ -225,6 +225,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008690,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ef61cea4525c4eaae77aaa5ff3cab94",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":421166429,
-    "wof:lastmodified":1566676475,
+    "wof:lastmodified":1582343529,
     "wof:name":"Ayacucho",
     "wof:parent_id":421177937,
     "wof:placetype":"locality",

--- a/data/421/167/831/421167831.geojson
+++ b/data/421/167/831/421167831.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008745,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"215a75cb4c2f31a4cd2891432746f4f4",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421167831,
-    "wof:lastmodified":1566676487,
+    "wof:lastmodified":1582343533,
     "wof:name":"San Rom\u00e1n",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/167/977/421167977.geojson
+++ b/data/421/167/977/421167977.geojson
@@ -80,6 +80,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008750,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5c1ac3be5d811d1adfa83e223c1baa9",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":421167977,
-    "wof:lastmodified":1566676486,
+    "wof:lastmodified":1582343533,
     "wof:name":"San Miguel de Cauri",
     "wof:parent_id":421181301,
     "wof:placetype":"locality",

--- a/data/421/170/085/421170085.geojson
+++ b/data/421/170/085/421170085.geojson
@@ -294,6 +294,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008836,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"8130096d75c4390b01328cfda80cf577",
     "wof:hierarchy":[
         {
@@ -305,7 +308,7 @@
         }
     ],
     "wof:id":421170085,
-    "wof:lastmodified":1566676535,
+    "wof:lastmodified":1582343547,
     "wof:name":"Tarapoto",
     "wof:parent_id":421175177,
     "wof:placetype":"locality",

--- a/data/421/170/339/421170339.geojson
+++ b/data/421/170/339/421170339.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008849,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8a768a80c7deb8065e37c7b3252af40a",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421170339,
-    "wof:lastmodified":1566676535,
+    "wof:lastmodified":1582343547,
     "wof:name":"Andahuaylas",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/170/341/421170341.geojson
+++ b/data/421/170/341/421170341.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008849,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7771b86c61c4be44b7f0137872cbd5a",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421170341,
-    "wof:lastmodified":1566676536,
+    "wof:lastmodified":1582343548,
     "wof:name":"Sechura",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/170/655/421170655.geojson
+++ b/data/421/170/655/421170655.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008862,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d76015337d81cdb2d61af53307c82596",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421170655,
-    "wof:lastmodified":1566676538,
+    "wof:lastmodified":1582343548,
     "wof:name":"Abancay",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/170/661/421170661.geojson
+++ b/data/421/170/661/421170661.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008862,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e6009cd22d11505fe15fd280006f3b09",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421170661,
-    "wof:lastmodified":1566676536,
+    "wof:lastmodified":1582343547,
     "wof:name":"Huaylas",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/170/663/421170663.geojson
+++ b/data/421/170/663/421170663.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008862,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6dbd4682d59387fa9fbc7592aa527c01",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421170663,
-    "wof:lastmodified":1566676538,
+    "wof:lastmodified":1582343548,
     "wof:name":"Luya",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/421/170/665/421170665.geojson
+++ b/data/421/170/665/421170665.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008862,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b8b2602c8fbab6302984e9b422ef00b",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421170665,
-    "wof:lastmodified":1566676538,
+    "wof:lastmodified":1582343549,
     "wof:name":"Manu",
     "wof:parent_id":85675847,
     "wof:placetype":"county",

--- a/data/421/170/671/421170671.geojson
+++ b/data/421/170/671/421170671.geojson
@@ -107,6 +107,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008862,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"18fbcd64d1e2219e52764249d3d3b75b",
     "wof:hierarchy":[
         {
@@ -117,7 +120,7 @@
         }
     ],
     "wof:id":421170671,
-    "wof:lastmodified":1566676537,
+    "wof:lastmodified":1582343548,
     "wof:name":"Tocache",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/421/170/673/421170673.geojson
+++ b/data/421/170/673/421170673.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008863,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b3be76224c3a473b0636e8f37efd82c7",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421170673,
-    "wof:lastmodified":1566676535,
+    "wof:lastmodified":1582343547,
     "wof:name":"Tayacaja",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/170/675/421170675.geojson
+++ b/data/421/170/675/421170675.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008863,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4e7851f6213478185e0959691175523",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421170675,
-    "wof:lastmodified":1566676535,
+    "wof:lastmodified":1582343547,
     "wof:name":"Tarma",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/170/677/421170677.geojson
+++ b/data/421/170/677/421170677.geojson
@@ -349,6 +349,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008863,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"830f8c57b828d812400cf4c4e1c0d337",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
         }
     ],
     "wof:id":421170677,
-    "wof:lastmodified":1566676537,
+    "wof:lastmodified":1582343548,
     "wof:name":"Trujillo",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/171/561/421171561.geojson
+++ b/data/421/171/561/421171561.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008898,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b6049749404c28490fcf17425ae15221",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421171561,
-    "wof:lastmodified":1566676546,
+    "wof:lastmodified":1582343552,
     "wof:name":"Ayabaca",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/171/957/421171957.geojson
+++ b/data/421/171/957/421171957.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008913,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a040fe70e5201e9843ff1b5aca15fec4",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421171957,
-    "wof:lastmodified":1566676547,
+    "wof:lastmodified":1582343553,
     "wof:name":"Coronel Portillo",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/421/171/959/421171959.geojson
+++ b/data/421/171/959/421171959.geojson
@@ -151,6 +151,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008913,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7346f4c240aafd5781fa8aa0f97dd6e",
     "wof:hierarchy":[
         {
@@ -161,7 +164,7 @@
         }
     ],
     "wof:id":421171959,
-    "wof:lastmodified":1566676548,
+    "wof:lastmodified":1582343553,
     "wof:name":"Gral. S\u00e1nchez Cerro",
     "wof:parent_id":85675857,
     "wof:placetype":"county",

--- a/data/421/171/961/421171961.geojson
+++ b/data/421/171/961/421171961.geojson
@@ -212,6 +212,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d39a76c894ae9e625b83b7da7426017",
     "wof:hierarchy":[
         {
@@ -222,7 +225,7 @@
         }
     ],
     "wof:id":421171961,
-    "wof:lastmodified":1566676548,
+    "wof:lastmodified":1582343553,
     "wof:name":"Tacna",
     "wof:parent_id":85675861,
     "wof:placetype":"county",

--- a/data/421/171/963/421171963.geojson
+++ b/data/421/171/963/421171963.geojson
@@ -128,6 +128,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab5c052806eb12ef4c5435c0500be706",
     "wof:hierarchy":[
         {
@@ -138,7 +141,7 @@
         }
     ],
     "wof:id":421171963,
-    "wof:lastmodified":1566676547,
+    "wof:lastmodified":1582343552,
     "wof:name":"Moho",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/171/973/421171973.geojson
+++ b/data/421/171/973/421171973.geojson
@@ -174,6 +174,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008914,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c5a80db0bd378aa5d2264d4b9b6d4f0a",
     "wof:hierarchy":[
         {
@@ -184,7 +187,7 @@
         }
     ],
     "wof:id":421171973,
-    "wof:lastmodified":1566676548,
+    "wof:lastmodified":1582343553,
     "wof:name":"Mariscal Luzuriaga",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/172/423/421172423.geojson
+++ b/data/421/172/423/421172423.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008940,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b1546f2b75b6f3f8701a2d1fb8905d2",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421172423,
-    "wof:lastmodified":1566676510,
+    "wof:lastmodified":1582343540,
     "wof:name":"Cajamarca",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/172/425/421172425.geojson
+++ b/data/421/172/425/421172425.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008940,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"770f1823ba80c8350ad9be786a07dbc6",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421172425,
-    "wof:lastmodified":1566676509,
+    "wof:lastmodified":1582343540,
     "wof:name":"Cusco",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/172/463/421172463.geojson
+++ b/data/421/172/463/421172463.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008943,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e2b66080fc9e929f17cd5f022dedaf7",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421172463,
-    "wof:lastmodified":1566676510,
+    "wof:lastmodified":1582343540,
     "wof:name":"Pataz",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/172/895/421172895.geojson
+++ b/data/421/172/895/421172895.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459008958,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4604e7a919d5cc996aecede504fbde89",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421172895,
-    "wof:lastmodified":1566676510,
+    "wof:lastmodified":1582343540,
     "wof:name":"Utcubamba",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/421/175/155/421175155.geojson
+++ b/data/421/175/155/421175155.geojson
@@ -159,6 +159,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"53438b23b14f96e8cd2f0edc26b208b9",
     "wof:hierarchy":[
         {
@@ -169,7 +172,7 @@
         }
     ],
     "wof:id":421175155,
-    "wof:lastmodified":1566676523,
+    "wof:lastmodified":1582343543,
     "wof:name":"Atalaya",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/421/175/157/421175157.geojson
+++ b/data/421/175/157/421175157.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3569e766d39d5b46c2b11ec0d55b4488",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421175157,
-    "wof:lastmodified":1566676519,
+    "wof:lastmodified":1582343541,
     "wof:name":"Calca",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/175/159/421175159.geojson
+++ b/data/421/175/159/421175159.geojson
@@ -134,6 +134,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8205edc5a69cd15648f219469132f55d",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":421175159,
-    "wof:lastmodified":1566676519,
+    "wof:lastmodified":1582343541,
     "wof:name":"Caman\u00e1",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/175/161/421175161.geojson
+++ b/data/421/175/161/421175161.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1c320f9c9f7e95eb69b72a2decc5a744",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421175161,
-    "wof:lastmodified":1566676520,
+    "wof:lastmodified":1582343542,
     "wof:name":"Aymaraes",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/175/163/421175163.geojson
+++ b/data/421/175/163/421175163.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d7017ea3537dacbd9e868893036f5802",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421175163,
-    "wof:lastmodified":1566676523,
+    "wof:lastmodified":1582343543,
     "wof:name":"Contralmirante Villar",
     "wof:parent_id":85675831,
     "wof:placetype":"county",

--- a/data/421/175/167/421175167.geojson
+++ b/data/421/175/167/421175167.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009057,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be3966615db161b578ac5970d2e85940",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421175167,
-    "wof:lastmodified":1566676520,
+    "wof:lastmodified":1582343542,
     "wof:name":"Huancavelica",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/175/173/421175173.geojson
+++ b/data/421/175/173/421175173.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009058,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9f14280ead67c551ba66a22ccb113b9",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421175173,
-    "wof:lastmodified":1566676522,
+    "wof:lastmodified":1582343543,
     "wof:name":"Loreto",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/175/175/421175175.geojson
+++ b/data/421/175/175/421175175.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009058,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c841179aa91820628a14dc2565d24a8a",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421175175,
-    "wof:lastmodified":1566676522,
+    "wof:lastmodified":1582343543,
     "wof:name":"Oxapampa",
     "wof:parent_id":85675883,
     "wof:placetype":"county",

--- a/data/421/175/177/421175177.geojson
+++ b/data/421/175/177/421175177.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009058,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7b9ea26a5d13b9c5115e8d4cc0e8b58f",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421175177,
-    "wof:lastmodified":1566676524,
+    "wof:lastmodified":1582343544,
     "wof:name":"San Mart\u00edn",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/421/175/219/421175219.geojson
+++ b/data/421/175/219/421175219.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009060,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e303c7ccfcb387716a42785db0002952",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421175219,
-    "wof:lastmodified":1566676521,
+    "wof:lastmodified":1582343542,
     "wof:name":"Mariscal Ram\u00f3n Castilla",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/175/433/421175433.geojson
+++ b/data/421/175/433/421175433.geojson
@@ -481,6 +481,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009067,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"828649c4a9a1053b1be21742db234806",
     "wof:hierarchy":[
         {
@@ -491,7 +494,7 @@
         }
     ],
     "wof:id":421175433,
-    "wof:lastmodified":1566676524,
+    "wof:lastmodified":1582343544,
     "wof:name":"Asunci\u00f3n",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/175/847/421175847.geojson
+++ b/data/421/175/847/421175847.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009081,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8f465f5410558d1adc197a3c53c5b22a",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":421175847,
-    "wof:lastmodified":1566676524,
+    "wof:lastmodified":1582343544,
     "wof:name":"Calca",
     "wof:parent_id":1108693905,
     "wof:placetype":"locality",

--- a/data/421/176/081/421176081.geojson
+++ b/data/421/176/081/421176081.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009095,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"587fd0b83df5c61e767d0305311c8f12",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421176081,
-    "wof:lastmodified":1566676546,
+    "wof:lastmodified":1582343552,
     "wof:name":"Dos De Mayo",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/177/057/421177057.geojson
+++ b/data/421/177/057/421177057.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009131,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c11f3b4d93f4f41bffe938c81db43d2",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421177057,
-    "wof:lastmodified":1566676540,
+    "wof:lastmodified":1582343549,
     "wof:name":"San Ignacio",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/177/079/421177079.geojson
+++ b/data/421/177/079/421177079.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009132,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"358e193f5809f06348df1c66ec57885e",
     "wof:hierarchy":[
         {
@@ -164,7 +167,7 @@
         }
     ],
     "wof:id":421177079,
-    "wof:lastmodified":1566676539,
+    "wof:lastmodified":1582343549,
     "wof:name":"S\u00e1nchez Carri\u00f3n",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/177/937/421177937.geojson
+++ b/data/421/177/937/421177937.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009165,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b27c1ec6f346e2f6e654e5ac3321b13b",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421177937,
-    "wof:lastmodified":1566676539,
+    "wof:lastmodified":1582343549,
     "wof:name":"Huaytar\u00e1",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/179/893/421179893.geojson
+++ b/data/421/179/893/421179893.geojson
@@ -197,6 +197,7 @@
     "qs:woe_id":418529,
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "wof:belongsto":[
@@ -215,6 +216,10 @@
     },
     "wof:country":"PE",
     "wof:created":1459009237,
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0be643c169778d57406c8850e9ed14eb",
     "wof:hierarchy":[
         {
@@ -226,7 +231,7 @@
         }
     ],
     "wof:id":421179893,
-    "wof:lastmodified":1561777738,
+    "wof:lastmodified":1582343550,
     "wof:name":"Ilo",
     "wof:parent_id":421185587,
     "wof:placetype":"locality",

--- a/data/421/180/013/421180013.geojson
+++ b/data/421/180/013/421180013.geojson
@@ -83,6 +83,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009241,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2be8e5009e8e91e1adbf88bb58235605",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
         }
     ],
     "wof:id":421180013,
-    "wof:lastmodified":1566676495,
+    "wof:lastmodified":1582343535,
     "wof:name":"Palpa",
     "wof:parent_id":421197033,
     "wof:placetype":"locality",

--- a/data/421/180/077/421180077.geojson
+++ b/data/421/180/077/421180077.geojson
@@ -167,6 +167,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009243,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0cd4bfc0e401a12cc5bdd74cb8cae8df",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":421180077,
-    "wof:lastmodified":1566676494,
+    "wof:lastmodified":1582343535,
     "wof:name":"Nazca",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/181/301/421181301.geojson
+++ b/data/421/181/301/421181301.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009292,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"008dbce658c3659cd25e2b29749a7ff3",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421181301,
-    "wof:lastmodified":1566676518,
+    "wof:lastmodified":1582343541,
     "wof:name":"Lauricocha",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/182/239/421182239.geojson
+++ b/data/421/182/239/421182239.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ebd3bc70028d291a24eab4cb2ca17f4",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421182239,
-    "wof:lastmodified":1566676545,
+    "wof:lastmodified":1582343552,
     "wof:name":"Yauli",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/182/241/421182241.geojson
+++ b/data/421/182/241/421182241.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009323,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"56b0f9163e8ddd0ed81fdab36e6e2d06",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421182241,
-    "wof:lastmodified":1566676544,
+    "wof:lastmodified":1582343551,
     "wof:name":"Maynas",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/182/363/421182363.geojson
+++ b/data/421/182/363/421182363.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009327,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d1c48d64e6218ecb3aa62a30b500f0d",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421182363,
-    "wof:lastmodified":1566676543,
+    "wof:lastmodified":1582343551,
     "wof:name":"Ica",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/182/365/421182365.geojson
+++ b/data/421/182/365/421182365.geojson
@@ -139,6 +139,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009327,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa1d89da43eaf000d916d3a95d076253",
     "wof:hierarchy":[
         {
@@ -149,7 +152,7 @@
         }
     ],
     "wof:id":421182365,
-    "wof:lastmodified":1566676543,
+    "wof:lastmodified":1582343551,
     "wof:name":"Islay",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/183/001/421183001.geojson
+++ b/data/421/183/001/421183001.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009354,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7376dd39f42a5390f083e51d79192ff9",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421183001,
-    "wof:lastmodified":1566676542,
+    "wof:lastmodified":1582343550,
     "wof:name":"Urubamba",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/183/855/421183855.geojson
+++ b/data/421/183/855/421183855.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8ab5d9599e49a5cf5a86d1e28ab46a6c",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421183855,
-    "wof:lastmodified":1566676542,
+    "wof:lastmodified":1582343550,
     "wof:name":"Acobamba",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/183/857/421183857.geojson
+++ b/data/421/183/857/421183857.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a1aa472332785b07034b526254bbd47",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421183857,
-    "wof:lastmodified":1566676541,
+    "wof:lastmodified":1582343550,
     "wof:name":"Carabaya",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/183/859/421183859.geojson
+++ b/data/421/183/859/421183859.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c223dc25c878dfe6e6384868cfa2a9b",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421183859,
-    "wof:lastmodified":1566676540,
+    "wof:lastmodified":1582343550,
     "wof:name":"Celend\u00edn",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/183/861/421183861.geojson
+++ b/data/421/183/861/421183861.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e675a8c0c7b8fae579686c46c4538a21",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421183861,
-    "wof:lastmodified":1566676541,
+    "wof:lastmodified":1582343550,
     "wof:name":"Huancan\u00e9",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/184/147/421184147.geojson
+++ b/data/421/184/147/421184147.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009402,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1b4c24bfb62098961021161fd8bb9ff1",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":421184147,
-    "wof:lastmodified":1566676534,
+    "wof:lastmodified":1582343547,
     "wof:name":"Jun\u00edn",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/184/497/421184497.geojson
+++ b/data/421/184/497/421184497.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009412,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ccd489022ba953bc43f94ddbd292bd88",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421184497,
-    "wof:lastmodified":1566676533,
+    "wof:lastmodified":1582343546,
     "wof:name":"Huarmey",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/184/599/421184599.geojson
+++ b/data/421/184/599/421184599.geojson
@@ -147,6 +147,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f3970583eac604c3359429c2bbe46c66",
     "wof:hierarchy":[
         {
@@ -157,7 +160,7 @@
         }
     ],
     "wof:id":421184599,
-    "wof:lastmodified":1566676534,
+    "wof:lastmodified":1582343547,
     "wof:name":"Chep\u00e9n",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/184/603/421184603.geojson
+++ b/data/421/184/603/421184603.geojson
@@ -135,6 +135,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009416,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bbec2d64ac6e2e927777982db734fe38",
     "wof:hierarchy":[
         {
@@ -145,7 +148,7 @@
         }
     ],
     "wof:id":421184603,
-    "wof:lastmodified":1566676533,
+    "wof:lastmodified":1582343547,
     "wof:name":"Churcampa",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/185/275/421185275.geojson
+++ b/data/421/185/275/421185275.geojson
@@ -163,6 +163,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009437,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c25878fce945d2682f4ee9282b101d2b",
     "wof:hierarchy":[
         {
@@ -173,7 +176,7 @@
         }
     ],
     "wof:id":421185275,
-    "wof:lastmodified":1566676549,
+    "wof:lastmodified":1582343554,
     "wof:name":"Ja\u00e9n",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/185/309/421185309.geojson
+++ b/data/421/185/309/421185309.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009438,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5396d300a668d6c7b4319488a60ff99d",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421185309,
-    "wof:lastmodified":1566676549,
+    "wof:lastmodified":1582343553,
     "wof:name":"Chiclayo",
     "wof:parent_id":85675821,
     "wof:placetype":"county",

--- a/data/421/185/311/421185311.geojson
+++ b/data/421/185/311/421185311.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009438,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0fbc947ba62e209b0e269089c3570d22",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421185311,
-    "wof:lastmodified":1566676551,
+    "wof:lastmodified":1582343554,
     "wof:name":"Huamanga",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/185/313/421185313.geojson
+++ b/data/421/185/313/421185313.geojson
@@ -161,6 +161,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009439,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7e0e675c688e6aea1f694d2bd46279fe",
     "wof:hierarchy":[
         {
@@ -171,7 +174,7 @@
         }
     ],
     "wof:id":421185313,
-    "wof:lastmodified":1566676550,
+    "wof:lastmodified":1582343554,
     "wof:name":"Hu\u00e1nuco",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/185/587/421185587.geojson
+++ b/data/421/185/587/421185587.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009448,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4f0b683a1869852622155c12bd279f3",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421185587,
-    "wof:lastmodified":1566676550,
+    "wof:lastmodified":1582343554,
     "wof:name":"Ilo",
     "wof:parent_id":85675857,
     "wof:placetype":"county",

--- a/data/421/186/269/421186269.geojson
+++ b/data/421/186/269/421186269.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009475,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8a4ccef477c54c4e61472580594ff62a",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421186269,
-    "wof:lastmodified":1566676513,
+    "wof:lastmodified":1582343540,
     "wof:name":"Chucuito",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/186/777/421186777.geojson
+++ b/data/421/186/777/421186777.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009491,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa809eaf1f93e8f55183ec6387589765",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421186777,
-    "wof:lastmodified":1566676514,
+    "wof:lastmodified":1582343541,
     "wof:name":"Independencia",
     "wof:parent_id":421202549,
     "wof:placetype":"locality",

--- a/data/421/186/795/421186795.geojson
+++ b/data/421/186/795/421186795.geojson
@@ -329,6 +329,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009492,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56af8cd77970184f6adbff95e99b3e83",
     "wof:hierarchy":[
         {
@@ -340,7 +343,7 @@
         }
     ],
     "wof:id":421186795,
-    "wof:lastmodified":1566676515,
+    "wof:lastmodified":1582343541,
     "wof:name":"Ica",
     "wof:parent_id":421182363,
     "wof:placetype":"locality",

--- a/data/421/186/805/421186805.geojson
+++ b/data/421/186/805/421186805.geojson
@@ -572,6 +572,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009492,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9860ab0ce326c48e309cbd9b5d8c881d",
     "wof:hierarchy":[
         {
@@ -583,7 +586,7 @@
         }
     ],
     "wof:id":421186805,
-    "wof:lastmodified":1566676514,
+    "wof:lastmodified":1582343541,
     "wof:name":"Lima",
     "wof:parent_id":421202549,
     "wof:placetype":"locality",

--- a/data/421/186/819/421186819.geojson
+++ b/data/421/186/819/421186819.geojson
@@ -193,6 +193,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009492,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"30cd9e815f69ca12f60d16f4cc67667d",
     "wof:hierarchy":[
         {
@@ -204,7 +207,7 @@
         }
     ],
     "wof:id":421186819,
-    "wof:lastmodified":1566676512,
+    "wof:lastmodified":1582343540,
     "wof:name":"Nauta",
     "wof:parent_id":421175173,
     "wof:placetype":"locality",

--- a/data/421/186/849/421186849.geojson
+++ b/data/421/186/849/421186849.geojson
@@ -144,6 +144,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009494,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"4f4d67eef4a04d9adb3a79c5476b6e92",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421186849,
-    "wof:lastmodified":1566676515,
+    "wof:lastmodified":1582343541,
     "wof:name":"Tournavista",
     "wof:parent_id":421194457,
     "wof:placetype":"locality",

--- a/data/421/186/885/421186885.geojson
+++ b/data/421/186/885/421186885.geojson
@@ -374,6 +374,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009495,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"362708da3a58cfab393bea1fd3443c0e",
     "wof:hierarchy":[
         {
@@ -385,7 +388,7 @@
         }
     ],
     "wof:id":421186885,
-    "wof:lastmodified":1566676516,
+    "wof:lastmodified":1582343541,
     "wof:name":"Cuzco",
     "wof:parent_id":421172425,
     "wof:placetype":"locality",

--- a/data/421/187/177/421187177.geojson
+++ b/data/421/187/177/421187177.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009504,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"376ba3b818743c6a8678c25020a4deeb",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421187177,
-    "wof:lastmodified":1566676502,
+    "wof:lastmodified":1582343538,
     "wof:name":"Talara",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/187/837/421187837.geojson
+++ b/data/421/187/837/421187837.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009525,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a56affabc9a571989be88f1404a6f5a7",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421187837,
-    "wof:lastmodified":1566676501,
+    "wof:lastmodified":1582343537,
     "wof:name":"Anta",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/187/839/421187839.geojson
+++ b/data/421/187/839/421187839.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009525,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dcb066d7d1c0bcb2d9d8a6900e3f0f9d",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421187839,
-    "wof:lastmodified":1566676501,
+    "wof:lastmodified":1582343537,
     "wof:name":"Canas",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/187/843/421187843.geojson
+++ b/data/421/187/843/421187843.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009525,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdcbd8b5adbda0e7984c1a9b3f7d1ed4",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421187843,
-    "wof:lastmodified":1566676496,
+    "wof:lastmodified":1582343536,
     "wof:name":"Canchis",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/187/849/421187849.geojson
+++ b/data/421/187/849/421187849.geojson
@@ -158,6 +158,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91dc716923b04e57e8bc97a9d5db3c2e",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":421187849,
-    "wof:lastmodified":1566676499,
+    "wof:lastmodified":1582343537,
     "wof:name":"Chanchamayo",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/187/851/421187851.geojson
+++ b/data/421/187/851/421187851.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2081bae5f4b8a73ed7836322bb4b38a2",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421187851,
-    "wof:lastmodified":1566676497,
+    "wof:lastmodified":1582343536,
     "wof:name":"Huari",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/187/855/421187855.geojson
+++ b/data/421/187/855/421187855.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d91c93e400392c054eaef8a0affffc37",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421187855,
-    "wof:lastmodified":1566676501,
+    "wof:lastmodified":1582343537,
     "wof:name":"Lambayeque",
     "wof:parent_id":85675821,
     "wof:placetype":"county",

--- a/data/421/187/857/421187857.geojson
+++ b/data/421/187/857/421187857.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebb2515ba88a1e4afaae7c36c334ee67",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421187857,
-    "wof:lastmodified":1566676497,
+    "wof:lastmodified":1582343536,
     "wof:name":"Lampa",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/187/861/421187861.geojson
+++ b/data/421/187/861/421187861.geojson
@@ -328,6 +328,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"89f5696591e80c0bba11f98298eacae5",
     "wof:hierarchy":[
         {
@@ -338,7 +341,7 @@
         }
     ],
     "wof:id":421187861,
-    "wof:lastmodified":1566676497,
+    "wof:lastmodified":1582343536,
     "wof:name":"Melgar",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/187/863/421187863.geojson
+++ b/data/421/187/863/421187863.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"241daf58fe6d78e77798363541abac4b",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421187863,
-    "wof:lastmodified":1566676502,
+    "wof:lastmodified":1582343538,
     "wof:name":"Tumbes",
     "wof:parent_id":85675831,
     "wof:placetype":"county",

--- a/data/421/187/865/421187865.geojson
+++ b/data/421/187/865/421187865.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63716fc9ab1b077efbee36ea66651b0b",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":421187865,
-    "wof:lastmodified":1566676500,
+    "wof:lastmodified":1582343537,
     "wof:name":"Ucayali",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/187/867/421187867.geojson
+++ b/data/421/187/867/421187867.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009526,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1760e95620418fd9308bd4455cb8df6d",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421187867,
-    "wof:lastmodified":1566676498,
+    "wof:lastmodified":1582343536,
     "wof:name":"Yungay",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/187/921/421187921.geojson
+++ b/data/421/187/921/421187921.geojson
@@ -261,6 +261,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"68edbcf4c21f3777dc140c99527da4a1",
     "wof:hierarchy":[
         {
@@ -271,7 +274,7 @@
         }
     ],
     "wof:id":421187921,
-    "wof:lastmodified":1566676503,
+    "wof:lastmodified":1582343538,
     "wof:name":"Huaraz",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/187/925/421187925.geojson
+++ b/data/421/187/925/421187925.geojson
@@ -97,6 +97,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"111067e20d13baef5ad2e1a91983a583",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":421187925,
-    "wof:lastmodified":1566676498,
+    "wof:lastmodified":1582343536,
     "wof:name":"Leoncio Prado",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/187/933/421187933.geojson
+++ b/data/421/187/933/421187933.geojson
@@ -253,6 +253,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009528,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0507c4c91140fa3c11a4c1f568903d27",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
         }
     ],
     "wof:id":421187933,
-    "wof:lastmodified":1566676499,
+    "wof:lastmodified":1582343537,
     "wof:name":"Callao",
     "wof:parent_id":85675817,
     "wof:placetype":"county",

--- a/data/421/188/085/421188085.geojson
+++ b/data/421/188/085/421188085.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009533,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f7d60f43f90eeabd3386f4a27ab00fa5",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":421188085,
-    "wof:lastmodified":1566676506,
+    "wof:lastmodified":1582343538,
     "wof:name":"Alto Amazonas",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/188/283/421188283.geojson
+++ b/data/421/188/283/421188283.geojson
@@ -162,6 +162,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009540,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"871f6af6704bffc8b0380059bb5e80a6",
     "wof:hierarchy":[
         {
@@ -172,7 +175,7 @@
         }
     ],
     "wof:id":421188283,
-    "wof:lastmodified":1566676508,
+    "wof:lastmodified":1582343539,
     "wof:name":"Chupaca",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/188/715/421188715.geojson
+++ b/data/421/188/715/421188715.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"01b389398ceafd4710a2e08d48f763f7",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421188715,
-    "wof:lastmodified":1566676507,
+    "wof:lastmodified":1582343539,
     "wof:name":"Jauja",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/188/717/421188717.geojson
+++ b/data/421/188/717/421188717.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"26bf45935ce106ab93a5b8c02268431d",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421188717,
-    "wof:lastmodified":1566676509,
+    "wof:lastmodified":1582343539,
     "wof:name":"Otuzco",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/188/719/421188719.geojson
+++ b/data/421/188/719/421188719.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8cc10adc861c91e710f809e86d65b90",
     "wof:hierarchy":[
         {
@@ -158,7 +161,7 @@
         }
     ],
     "wof:id":421188719,
-    "wof:lastmodified":1566676508,
+    "wof:lastmodified":1582343539,
     "wof:name":"Aija",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/188/721/421188721.geojson
+++ b/data/421/188/721/421188721.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6666d18565657ff2db7427a6544fbb44",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421188721,
-    "wof:lastmodified":1566676508,
+    "wof:lastmodified":1582343539,
     "wof:name":"Angaraes",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/188/725/421188725.geojson
+++ b/data/421/188/725/421188725.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8fd76784fa0e1c4f44c7b5d033d35c05",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421188725,
-    "wof:lastmodified":1566676506,
+    "wof:lastmodified":1582343539,
     "wof:name":"Bol\u00edvar",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/188/727/421188727.geojson
+++ b/data/421/188/727/421188727.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009576,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"676ca27cb42bcd8e8aca24a81534e55b",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421188727,
-    "wof:lastmodified":1566676509,
+    "wof:lastmodified":1582343540,
     "wof:name":"Ferre\u00f1afe",
     "wof:parent_id":85675821,
     "wof:placetype":"county",

--- a/data/421/188/857/421188857.geojson
+++ b/data/421/188/857/421188857.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009586,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f0a687bf201db4dd49a368e520383e39",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421188857,
-    "wof:lastmodified":1566676506,
+    "wof:lastmodified":1582343539,
     "wof:name":"Morrop\u00f3n",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/191/399/421191399.geojson
+++ b/data/421/191/399/421191399.geojson
@@ -157,6 +157,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009690,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d1b6c5506ece3ed0b5da9d6f879c0b1",
     "wof:hierarchy":[
         {
@@ -167,7 +170,7 @@
         }
     ],
     "wof:id":421191399,
-    "wof:lastmodified":1566676527,
+    "wof:lastmodified":1582343545,
     "wof:name":"Vir\u00fa",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/192/221/421192221.geojson
+++ b/data/421/192/221/421192221.geojson
@@ -182,6 +182,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009729,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"8306b4c25770d507f89036577fb635c0",
     "wof:hierarchy":[
         {
@@ -193,7 +196,7 @@
         }
     ],
     "wof:id":421192221,
-    "wof:lastmodified":1566676476,
+    "wof:lastmodified":1582343530,
     "wof:name":"Casma",
     "wof:parent_id":421202213,
     "wof:placetype":"locality",

--- a/data/421/192/243/421192243.geojson
+++ b/data/421/192/243/421192243.geojson
@@ -93,6 +93,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009730,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ac643ca2816a68079b6f98c255aaffd",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421192243,
-    "wof:lastmodified":1566676476,
+    "wof:lastmodified":1582343530,
     "wof:name":"San Bartolo",
     "wof:parent_id":1108693967,
     "wof:placetype":"locality",

--- a/data/421/192/879/421192879.geojson
+++ b/data/421/192/879/421192879.geojson
@@ -133,6 +133,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"93441f26274df3a8ce8005677cbd0ddf",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
         }
     ],
     "wof:id":421192879,
-    "wof:lastmodified":1566676477,
+    "wof:lastmodified":1582343530,
     "wof:name":"Acomayo",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/192/883/421192883.geojson
+++ b/data/421/192/883/421192883.geojson
@@ -149,6 +149,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009752,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"406e5b0c7f80c8803e6b4adc34f53f47",
     "wof:hierarchy":[
         {
@@ -159,7 +162,7 @@
         }
     ],
     "wof:id":421192883,
-    "wof:lastmodified":1566676477,
+    "wof:lastmodified":1582343530,
     "wof:name":"Huancabamba",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/193/361/421193361.geojson
+++ b/data/421/193/361/421193361.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009768,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"47a0bf8a8ac1f104607558cfa860ffe5",
     "wof:hierarchy":[
         {
@@ -176,7 +179,7 @@
         }
     ],
     "wof:id":421193361,
-    "wof:lastmodified":1566676485,
+    "wof:lastmodified":1582343533,
     "wof:name":"Ascope",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/193/379/421193379.geojson
+++ b/data/421/193/379/421193379.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009769,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"730eb7af513e9d8f225e04263bc31db6",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421193379,
-    "wof:lastmodified":1566676483,
+    "wof:lastmodified":1582343532,
     "wof:name":"Caylloma",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/193/431/421193431.geojson
+++ b/data/421/193/431/421193431.geojson
@@ -156,6 +156,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009770,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3fb67d3f08291217328192aecaf840f4",
     "wof:hierarchy":[
         {
@@ -166,7 +169,7 @@
         }
     ],
     "wof:id":421193431,
-    "wof:lastmodified":1566676483,
+    "wof:lastmodified":1582343532,
     "wof:name":"Mariscal Nieto",
     "wof:parent_id":85675857,
     "wof:placetype":"county",

--- a/data/421/193/433/421193433.geojson
+++ b/data/421/193/433/421193433.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009770,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db91456e56df7a5dc78ac6e3e1edcdb3",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421193433,
-    "wof:lastmodified":1566676486,
+    "wof:lastmodified":1582343533,
     "wof:name":"Lucanas",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/194/075/421194075.geojson
+++ b/data/421/194/075/421194075.geojson
@@ -160,6 +160,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb048fd402dd6a0f6b8d61a50f619214",
     "wof:hierarchy":[
         {
@@ -170,7 +173,7 @@
         }
     ],
     "wof:id":421194075,
-    "wof:lastmodified":1566676481,
+    "wof:lastmodified":1582343531,
     "wof:name":"Caravel\u00ed",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/194/077/421194077.geojson
+++ b/data/421/194/077/421194077.geojson
@@ -145,6 +145,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9a36911a5676b215da70e13afd4a066",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
         }
     ],
     "wof:id":421194077,
-    "wof:lastmodified":1566676479,
+    "wof:lastmodified":1582343530,
     "wof:name":"Carhuaz",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/194/079/421194079.geojson
+++ b/data/421/194/079/421194079.geojson
@@ -116,6 +116,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f94e6b641b99a081ebb162d070feb114",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":421194079,
-    "wof:lastmodified":1566676479,
+    "wof:lastmodified":1582343530,
     "wof:name":"Chincheros",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/194/081/421194081.geojson
+++ b/data/421/194/081/421194081.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"37e4bae124209eb9bc1116d79da18c15",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421194081,
-    "wof:lastmodified":1566676481,
+    "wof:lastmodified":1582343531,
     "wof:name":"Huanta",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/194/085/421194085.geojson
+++ b/data/421/194/085/421194085.geojson
@@ -164,6 +164,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3c435b7048127228a623bae9cbbcefd1",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":421194085,
-    "wof:lastmodified":1566676479,
+    "wof:lastmodified":1582343530,
     "wof:name":"La Convenci\u00f3n",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/194/089/421194089.geojson
+++ b/data/421/194/089/421194089.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009793,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22a3e8db3d64955bc2cb70a15dd43d9b",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421194089,
-    "wof:lastmodified":1566676481,
+    "wof:lastmodified":1582343531,
     "wof:name":"Rioja",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/421/194/455/421194455.geojson
+++ b/data/421/194/455/421194455.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009806,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"808fcf6138c88eb5955becdb4676381f",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":421194455,
-    "wof:lastmodified":1566676480,
+    "wof:lastmodified":1582343531,
     "wof:name":"Pacasmayo",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/194/457/421194457.geojson
+++ b/data/421/194/457/421194457.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009806,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03f4af6eaa6ce486d07c41531ef0cf09",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421194457,
-    "wof:lastmodified":1566676483,
+    "wof:lastmodified":1582343532,
     "wof:name":"Puerto Inca",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/194/639/421194639.geojson
+++ b/data/421/194/639/421194639.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009814,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a4304accff7f2d48fee412567222ff6",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421194639,
-    "wof:lastmodified":1566676482,
+    "wof:lastmodified":1582343532,
     "wof:name":"Paruro",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/194/849/421194849.geojson
+++ b/data/421/194/849/421194849.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009822,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"848ce363a2c8f66d433ac9a25b8813f4",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421194849,
-    "wof:lastmodified":1566676482,
+    "wof:lastmodified":1582343531,
     "wof:name":"Pasco",
     "wof:parent_id":85675883,
     "wof:placetype":"county",

--- a/data/421/194/939/421194939.geojson
+++ b/data/421/194/939/421194939.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009825,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0a6c2f0a0f4a11aa81fab2b9d70568e8",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421194939,
-    "wof:lastmodified":1566676479,
+    "wof:lastmodified":1582343530,
     "wof:name":"Yarowilca",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/196/389/421196389.geojson
+++ b/data/421/196/389/421196389.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009880,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"826425824cf376af1ade07e0efe2c052",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":421196389,
-    "wof:lastmodified":1566676527,
+    "wof:lastmodified":1582343545,
     "wof:name":"Puerto Chicama Malabrigo",
     "wof:parent_id":421193361,
     "wof:placetype":"locality",

--- a/data/421/197/033/421197033.geojson
+++ b/data/421/197/033/421197033.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009900,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de094e4b991a18bceb104820ed3c4605",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421197033,
-    "wof:lastmodified":1566676528,
+    "wof:lastmodified":1582343545,
     "wof:name":"Palpa",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/197/577/421197577.geojson
+++ b/data/421/197/577/421197577.geojson
@@ -138,6 +138,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009918,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"615c30667cfa480d6027969fd6d87202",
     "wof:hierarchy":[
         {
@@ -148,7 +151,7 @@
         }
     ],
     "wof:id":421197577,
-    "wof:lastmodified":1566676528,
+    "wof:lastmodified":1582343545,
     "wof:name":"Pachitea",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/198/069/421198069.geojson
+++ b/data/421/198/069/421198069.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009935,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2eef7528e59ea4eb7e93884730c0d3b4",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421198069,
-    "wof:lastmodified":1566676526,
+    "wof:lastmodified":1582343545,
     "wof:name":"Arequipa",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/198/071/421198071.geojson
+++ b/data/421/198/071/421198071.geojson
@@ -226,6 +226,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009935,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f3be9912b7cad81995c0939869e018e",
     "wof:hierarchy":[
         {
@@ -236,7 +239,7 @@
         }
     ],
     "wof:id":421198071,
-    "wof:lastmodified":1566676525,
+    "wof:lastmodified":1582343544,
     "wof:name":"Pisco",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/198/073/421198073.geojson
+++ b/data/421/198/073/421198073.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009935,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3657b96e51644549e0fa3309b52c5bcf",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421198073,
-    "wof:lastmodified":1566676525,
+    "wof:lastmodified":1582343544,
     "wof:name":"Yunguyo",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/199/389/421199389.geojson
+++ b/data/421/199/389/421199389.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459009987,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9057b4e629a6ded2f56d33a101225d6a",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":421199389,
-    "wof:lastmodified":1566676529,
+    "wof:lastmodified":1582343546,
     "wof:name":"Hualmay",
     "wof:parent_id":1108693949,
     "wof:placetype":"locality",

--- a/data/421/199/871/421199871.geojson
+++ b/data/421/199/871/421199871.geojson
@@ -126,6 +126,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010003,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"76cc1ee9f482960ec44646220a6eb5b8",
     "wof:hierarchy":[
         {
@@ -136,7 +139,7 @@
         }
     ],
     "wof:id":421199871,
-    "wof:lastmodified":1566676529,
+    "wof:lastmodified":1582343545,
     "wof:name":"Zarumilla",
     "wof:parent_id":85675831,
     "wof:placetype":"county",

--- a/data/421/200/651/421200651.geojson
+++ b/data/421/200/651/421200651.geojson
@@ -127,6 +127,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010034,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"332ea62782334e97508a5b65ac06dd3c",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
         }
     ],
     "wof:id":421200651,
-    "wof:lastmodified":1566676530,
+    "wof:lastmodified":1582343546,
     "wof:name":"Puno",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/201/039/421201039.geojson
+++ b/data/421/201/039/421201039.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010049,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"463fce866eb67ba76a8374f643c08dd7",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421201039,
-    "wof:lastmodified":1566676532,
+    "wof:lastmodified":1582343546,
     "wof:name":"Padre Abad",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/421/202/207/421202207.geojson
+++ b/data/421/202/207/421202207.geojson
@@ -136,6 +136,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010109,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bec9f358f3e74254a64e4945faea67c8",
     "wof:hierarchy":[
         {
@@ -146,7 +149,7 @@
         }
     ],
     "wof:id":421202207,
-    "wof:lastmodified":1566676491,
+    "wof:lastmodified":1582343535,
     "wof:name":"Paucartambo",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/202/209/421202209.geojson
+++ b/data/421/202/209/421202209.geojson
@@ -146,6 +146,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010109,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d50dff99351d1eba70ad6f8ad09141f6",
     "wof:hierarchy":[
         {
@@ -156,7 +159,7 @@
         }
     ],
     "wof:id":421202209,
-    "wof:lastmodified":1566676491,
+    "wof:lastmodified":1582343534,
     "wof:name":"Quispicanchi",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/202/211/421202211.geojson
+++ b/data/421/202/211/421202211.geojson
@@ -142,6 +142,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010109,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17a639a80e71442243d9ac2fdf563ee4",
     "wof:hierarchy":[
         {
@@ -152,7 +155,7 @@
         }
     ],
     "wof:id":421202211,
-    "wof:lastmodified":1566676489,
+    "wof:lastmodified":1582343534,
     "wof:name":"Recuay",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/202/213/421202213.geojson
+++ b/data/421/202/213/421202213.geojson
@@ -92,6 +92,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010109,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0f42a4a00660833ccccae9dd793d615d",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":421202213,
-    "wof:lastmodified":1566676490,
+    "wof:lastmodified":1582343534,
     "wof:name":"Santa",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/202/523/421202523.geojson
+++ b/data/421/202/523/421202523.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8b60404fa9aa75b7bec1278ebf2cd71a",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421202523,
-    "wof:lastmodified":1566676492,
+    "wof:lastmodified":1582343535,
     "wof:name":"Castilla",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/202/549/421202549.geojson
+++ b/data/421/202/549/421202549.geojson
@@ -582,6 +582,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010121,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a4d809e44d4d3257faf9e8db2c1cae4",
     "wof:hierarchy":[
         {
@@ -592,7 +595,7 @@
         }
     ],
     "wof:id":421202549,
-    "wof:lastmodified":1566676491,
+    "wof:lastmodified":1582343535,
     "wof:name":"Lima",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/421/202/681/421202681.geojson
+++ b/data/421/202/681/421202681.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010126,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"71c980680daa7c9bdfee5723cce0a5a5",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421202681,
-    "wof:lastmodified":1566676490,
+    "wof:lastmodified":1582343534,
     "wof:name":"La Mar",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/203/205/421203205.geojson
+++ b/data/421/203/205/421203205.geojson
@@ -130,6 +130,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010143,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0bf6b9f79440aa9c0b6ce2ab3034694",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":421203205,
-    "wof:lastmodified":1566676488,
+    "wof:lastmodified":1582343534,
     "wof:name":"Espinar",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/203/221/421203221.geojson
+++ b/data/421/203/221/421203221.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"PE",
     "wof:created":1459010144,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5a3627acaa724e6e56dae5accdfddeb6",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":421203221,
-    "wof:lastmodified":1566676488,
+    "wof:lastmodified":1582343534,
     "wof:name":"Satipo",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/856/325/21/85632521.geojson
+++ b/data/856/325/21/85632521.geojson
@@ -925,7 +925,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1001,7 +1000,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1582343478,
+    "wof:lastmodified":1583222478,
     "wof:name":"Peru",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/325/21/85632521.geojson
+++ b/data/856/325/21/85632521.geojson
@@ -925,6 +925,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -979,6 +980,11 @@
     },
     "wof:country":"PE",
     "wof:country_alpha3":"PER",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"a1d224c8737ed2af3c305fcf8a6f44f1",
     "wof:hierarchy":[
         {
@@ -995,7 +1001,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674474,
+    "wof:lastmodified":1582343478,
     "wof:name":"Peru",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/758/17/85675817.geojson
+++ b/data/856/758/17/85675817.geojson
@@ -189,6 +189,9 @@
         "wd:id":"Q3199075"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0507c4c91140fa3c11a4c1f568903d27",
     "wof:hierarchy":[
         {
@@ -206,7 +209,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674481,
+    "wof:lastmodified":1582343484,
     "wof:name":"Callao",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/21/85675821.geojson
+++ b/data/856/758/21/85675821.geojson
@@ -325,6 +325,9 @@
         "wk:page":"Lambayeque Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f25b3f173ab2900e772328cee845f260",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674482,
+    "wof:lastmodified":1582343484,
     "wof:name":"Lambayeque",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/27/85675827.geojson
+++ b/data/856/758/27/85675827.geojson
@@ -340,6 +340,9 @@
         "wk:page":"Piura Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce243051f2d04c6325098c2b1b038b8f",
     "wof:hierarchy":[
         {
@@ -357,7 +360,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674481,
+    "wof:lastmodified":1582343483,
     "wof:name":"Piura",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/31/85675831.geojson
+++ b/data/856/758/31/85675831.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Tumbes Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ba98f2037512480da293accfc3bdf5f9",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674484,
+    "wof:lastmodified":1582343485,
     "wof:name":"Tumbes",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/35/85675835.geojson
+++ b/data/856/758/35/85675835.geojson
@@ -351,6 +351,9 @@
         "wk:page":"Apur\u00edmac Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e56aa2b087d9bbbe994e420bdefd058c",
     "wof:hierarchy":[
         {
@@ -368,7 +371,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674480,
+    "wof:lastmodified":1582343483,
     "wof:name":"Apurimac",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/39/85675839.geojson
+++ b/data/856/758/39/85675839.geojson
@@ -347,6 +347,9 @@
         "wk:page":"Arequipa Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"17d17149cadb40e2ea1852bed11f74fa",
     "wof:hierarchy":[
         {
@@ -364,7 +367,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674488,
+    "wof:lastmodified":1582343487,
     "wof:name":"Arequipa",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/43/85675843.geojson
+++ b/data/856/758/43/85675843.geojson
@@ -329,6 +329,9 @@
         "wk:page":"Cusco Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b3e75bf3d70e59621493d0bf7dbeafa",
     "wof:hierarchy":[
         {
@@ -346,7 +349,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674483,
+    "wof:lastmodified":1582343485,
     "wof:name":"Cusco",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/47/85675847.geojson
+++ b/data/856/758/47/85675847.geojson
@@ -339,6 +339,9 @@
         "wk:page":"Madre de Dios Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"83d2c14c69c56c588ee334b5e8f399ef",
     "wof:hierarchy":[
         {
@@ -356,7 +359,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674496,
+    "wof:lastmodified":1582343493,
     "wof:name":"Madre de Dios",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/57/85675857.geojson
+++ b/data/856/758/57/85675857.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Moquegua Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08be9c5a3403a2732ab1c8605e04040b",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674480,
+    "wof:lastmodified":1582343482,
     "wof:name":"Moquegua",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/61/85675861.geojson
+++ b/data/856/758/61/85675861.geojson
@@ -331,6 +331,9 @@
         "wk:page":"Tacna Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8d44405da32a9a3d362a67fb6ae16172",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674478,
+    "wof:lastmodified":1582343482,
     "wof:name":"Tacna",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/65/85675865.geojson
+++ b/data/856/758/65/85675865.geojson
@@ -346,6 +346,9 @@
         "wk:page":"Ancash Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"146b3273a478d5fc29f4e24ac6db088a",
     "wof:hierarchy":[
         {
@@ -363,7 +366,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674486,
+    "wof:lastmodified":1582343487,
     "wof:name":"Ancash",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/71/85675871.geojson
+++ b/data/856/758/71/85675871.geojson
@@ -327,6 +327,9 @@
         "wk:page":"Cajamarca Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab9ff8c269a9721b6573daf99bd51606",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674495,
+    "wof:lastmodified":1582343493,
     "wof:name":"Cajamarca",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/75/85675875.geojson
+++ b/data/856/758/75/85675875.geojson
@@ -341,6 +341,9 @@
         "wd:id":"Q215221"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ad1e0d2464f0cd085114a969efcf1787",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674482,
+    "wof:lastmodified":1582343484,
     "wof:name":"Huanuco",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/79/85675879.geojson
+++ b/data/856/758/79/85675879.geojson
@@ -349,6 +349,9 @@
         "wk:page":"La Libertad Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec5a3fb5fa3085e60dd1ede646f469b7",
     "wof:hierarchy":[
         {
@@ -366,7 +369,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674492,
+    "wof:lastmodified":1582343490,
     "wof:name":"La Libertad",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/83/85675883.geojson
+++ b/data/856/758/83/85675883.geojson
@@ -337,6 +337,9 @@
         "wk:page":"Pasco Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6b283b3bb5648d3e59d543bc528bf3e0",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674493,
+    "wof:lastmodified":1582343491,
     "wof:name":"Pasco",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/85/85675885.geojson
+++ b/data/856/758/85/85675885.geojson
@@ -337,6 +337,9 @@
         "wk:page":"San Mart\u00edn Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ce47d69eed0b59a4a6f4532ce30acb02",
     "wof:hierarchy":[
         {
@@ -354,7 +357,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674493,
+    "wof:lastmodified":1582343492,
     "wof:name":"San Martin",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/91/85675891.geojson
+++ b/data/856/758/91/85675891.geojson
@@ -338,6 +338,9 @@
         "wk:page":"Ucayali Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfcebb4c018abd7e302ea85689560fe3",
     "wof:hierarchy":[
         {
@@ -355,7 +358,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674485,
+    "wof:lastmodified":1582343486,
     "wof:name":"Ucayali",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/95/85675895.geojson
+++ b/data/856/758/95/85675895.geojson
@@ -343,6 +343,9 @@
         "wk:page":"Amazonas Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8567f2f53497c204886b5871388cceb8",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674479,
+    "wof:lastmodified":1582343482,
     "wof:name":"Amazonas",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/99/85675899.geojson
+++ b/data/856/758/99/85675899.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Loreto Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7cce04429f3abe4d93f9686beadab6dd",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674489,
+    "wof:lastmodified":1582343488,
     "wof:name":"Loreto",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/03/85675903.geojson
+++ b/data/856/759/03/85675903.geojson
@@ -350,6 +350,9 @@
         "wk:page":"Ayacucho Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"452cba6c1777ecc274fd836e61c67219",
     "wof:hierarchy":[
         {
@@ -367,7 +370,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674497,
+    "wof:lastmodified":1582343494,
     "wof:name":"Ayacucho",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/09/85675909.geojson
+++ b/data/856/759/09/85675909.geojson
@@ -311,6 +311,9 @@
         "wd:id":"Q211795"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8a344ece4bfd3fd84399bc4f01a9c9b",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1561777526,
+    "wof:lastmodified":1582343495,
     "wof:name":"Lima",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/11/85675911.geojson
+++ b/data/856/759/11/85675911.geojson
@@ -345,6 +345,9 @@
         "wk:page":"Huancavelica Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b47da10b056cd0f50a5ee0fa0fa34b88",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674498,
+    "wof:lastmodified":1582343494,
     "wof:name":"Huancavelica",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/15/85675915.geojson
+++ b/data/856/759/15/85675915.geojson
@@ -341,6 +341,9 @@
         "wk:page":"Ica Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49e18ee12f66c59318efcdf1f39f6be1",
     "wof:hierarchy":[
         {
@@ -358,7 +361,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674499,
+    "wof:lastmodified":1582343496,
     "wof:name":"Ica",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/19/85675919.geojson
+++ b/data/856/759/19/85675919.geojson
@@ -347,6 +347,9 @@
         "wk:page":"Jun\u00edn Region"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c82e48049c63e23c78de25f47be2a31",
     "wof:hierarchy":[
         {
@@ -364,7 +367,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1566674498,
+    "wof:lastmodified":1582343495,
     "wof:name":"Junin",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/857/649/91/85764991.geojson
+++ b/data/857/649/91/85764991.geojson
@@ -76,6 +76,9 @@
         "qs:id":1082772
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"952b3c4d87d55f8e47baab3787d845fb",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343477,
     "wof:name":"Carmen Pampa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/93/85764993.geojson
+++ b/data/857/649/93/85764993.geojson
@@ -84,6 +84,9 @@
         "qs_pg:id":1082775
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57f0cbc7d31cee0ee016acc64a24236d",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674473,
+    "wof:lastmodified":1582343477,
     "wof:name":"Chucuito",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/649/97/85764997.geojson
+++ b/data/857/649/97/85764997.geojson
@@ -122,6 +122,9 @@
         "qs_pg:id":423406
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e5a7fc69a2551e68bedcb573fb9a8aec",
     "wof:hierarchy":[
         {
@@ -137,7 +140,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674473,
+    "wof:lastmodified":1582343477,
     "wof:name":"Concha",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/01/85765001.geojson
+++ b/data/857/650/01/85765001.geojson
@@ -94,6 +94,9 @@
         "qs:id":1082776
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5753b5f15dee666afa857286822fd148",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"Cueva",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/07/85765007.geojson
+++ b/data/857/650/07/85765007.geojson
@@ -83,6 +83,9 @@
         "qs:id":475430
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b832414a88b6a9773cb46ca9be82403f",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"La Apacheta",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/11/85765011.geojson
+++ b/data/857/650/11/85765011.geojson
@@ -75,6 +75,9 @@
         "qs:id":1165424
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5adae86298b9b53f3d2b5ceaffd230c6",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"La Pampilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/13/85765013.geojson
+++ b/data/857/650/13/85765013.geojson
@@ -73,6 +73,9 @@
         "wk:page":"La Punta District"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b06a3c95aed09c91441379d1ccc11780",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"La Punta",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/19/85765019.geojson
+++ b/data/857/650/19/85765019.geojson
@@ -77,6 +77,9 @@
         "wk:page":"Miraflores District, Arequipa"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"784e1210432d0b753b70dd2f9f567a33",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"Miraflores",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/25/85765025.geojson
+++ b/data/857/650/25/85765025.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":475431
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"565b0e578ac0179d7c37fb0c808619e0",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674473,
+    "wof:lastmodified":1582343476,
     "wof:name":"Pachacutec",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/27/85765027.geojson
+++ b/data/857/650/27/85765027.geojson
@@ -110,6 +110,9 @@
         "qs:id":889986
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"88c4778774f32100f53f94aa56a98967",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"Pando",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/31/85765031.geojson
+++ b/data/857/650/31/85765031.geojson
@@ -75,6 +75,9 @@
         "qs:id":35869
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22ddbfff45e226c902ac390ebb3f9839",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"Sachaca",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/35/85765035.geojson
+++ b/data/857/650/35/85765035.geojson
@@ -80,6 +80,9 @@
         "qs:id":300673
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"22ad7417d48732e3e082868d2e933faa",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"San Miguel",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/39/85765039.geojson
+++ b/data/857/650/39/85765039.geojson
@@ -99,6 +99,9 @@
         "qs_pg:id":959456
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"800af31a4815c427705633ecac20a164",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674473,
+    "wof:lastmodified":1582343476,
     "wof:name":"Santa Luisa",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/43/85765043.geojson
+++ b/data/857/650/43/85765043.geojson
@@ -101,6 +101,9 @@
         "qs_pg:id":966823
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ade02e2478dbccc3fc35d6503b1dab01",
     "wof:hierarchy":[
         {
@@ -116,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674473,
+    "wof:lastmodified":1582343476,
     "wof:name":"Urbanizaci\u00f3n Salaverry",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/650/47/85765047.geojson
+++ b/data/857/650/47/85765047.geojson
@@ -79,6 +79,9 @@
         "qs:id":266536
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5220491515ac6a2cd546eba54caef908",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1534379398,
+    "wof:lastmodified":1582343476,
     "wof:name":"Zamacola",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/23/85765623.geojson
+++ b/data/857/656/23/85765623.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1196543
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1bd56eb8bedf57f742fa1cae5752e68c",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Brena",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/27/85765627.geojson
+++ b/data/857/656/27/85765627.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1196540
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"93dc61bd9112dae3b47a07e0bb07e4d6",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Jesus Maria",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/29/85765629.geojson
+++ b/data/857/656/29/85765629.geojson
@@ -100,6 +100,10 @@
         "wd:id":"Q2404480"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9836a2cb3fefc8dbab746944d1bfdd9f",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Carmen de la Legua",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/33/85765633.geojson
+++ b/data/857/656/33/85765633.geojson
@@ -98,6 +98,10 @@
         "qs_pg:id":1061903
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"796b5020e8b8859e1c62e7697bcd3b13",
     "wof:hierarchy":[
         {
@@ -113,7 +117,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Cercado",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/39/85765639.geojson
+++ b/data/857/656/39/85765639.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":237724
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a0d0ea40d752c6e28a01ca7e2ffb0ebc",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Ingenierie",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/43/85765643.geojson
+++ b/data/857/656/43/85765643.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":237725
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8cd45b4a0cf432abb6b48b5510f0ff82",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"27 de April",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/47/85765647.geojson
+++ b/data/857/656/47/85765647.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":986125
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"18f57b0149f89ce9a8fc39416293b97d",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"J C Mariategui",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/51/85765651.geojson
+++ b/data/857/656/51/85765651.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":896284
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"85066f2078cd062b031886be46fc1b71",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674469,
+    "wof:lastmodified":1582343475,
     "wof:name":"La Encantada",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/57/85765657.geojson
+++ b/data/857/656/57/85765657.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1329368
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"93a518eeae43ccfa226d7e1544616db8",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674469,
+    "wof:lastmodified":1582343475,
     "wof:name":"Los Proceres",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/61/85765661.geojson
+++ b/data/857/656/61/85765661.geojson
@@ -138,6 +138,10 @@
         "qs_pg:id":1061906
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39151c6e5967c55ae7dabe37207e1fdd",
     "wof:hierarchy":[
         {
@@ -153,7 +157,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674469,
+    "wof:lastmodified":1582343475,
     "wof:name":"San Roque",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/65/85765665.geojson
+++ b/data/857/656/65/85765665.geojson
@@ -329,6 +329,9 @@
         "qs_pg:id":1085992
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c14a9eb02d99508cff412ebf327d902e",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Aurora",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/73/85765673.geojson
+++ b/data/857/656/73/85765673.geojson
@@ -208,6 +208,10 @@
         "wd:id":"Q740887"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"30e99416f9049a5b2edc7da984e08ee2",
     "wof:hierarchy":[
         {
@@ -223,7 +227,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Gardenias",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/77/85765677.geojson
+++ b/data/857/656/77/85765677.geojson
@@ -89,6 +89,10 @@
         "qs_pg:id":1061902
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c862c9e771dde21344664d7910fc503",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Valle Hermoso",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/81/85765681.geojson
+++ b/data/857/656/81/85765681.geojson
@@ -111,6 +111,10 @@
         "wd:id":"Q2566267"
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f986bcd59dcc5cc6143a02e52ca596f",
     "wof:hierarchy":[
         {
@@ -126,7 +130,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"San Borja Norte",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/85/85765685.geojson
+++ b/data/857/656/85/85765685.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":219398
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"25071867f5401fd923d06b6c1a1de60f",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Corpac",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/656/97/85765697.geojson
+++ b/data/857/656/97/85765697.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":268821
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3ab3bdb90d9989ca2a53594025541ab4",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674470,
+    "wof:lastmodified":1582343476,
     "wof:name":"Cuidad del Pescador",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/01/85765701.geojson
+++ b/data/857/657/01/85765701.geojson
@@ -67,6 +67,10 @@
         "qs_pg:id":268822
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c7107c52a849322544d3399daf4aca0",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"La Chalaca",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/05/85765705.geojson
+++ b/data/857/657/05/85765705.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1109742
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24fa5a35ff9dead4c19f9d11d3b4a17a",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Castilla",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/11/85765711.geojson
+++ b/data/857/657/11/85765711.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":268823
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"be2a291bdc39b6d5d84f0c9df1d68af0",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Olaya",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/15/85765715.geojson
+++ b/data/857/657/15/85765715.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1087510
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"64c4486bcde2f44b5074fa6b92e57231",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"Barrios Altos",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/17/85765717.geojson
+++ b/data/857/657/17/85765717.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1087511
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"46488ed72eb3c26ce43ea7ae2aa25c2d",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Chacra Rios",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/21/85765721.geojson
+++ b/data/857/657/21/85765721.geojson
@@ -104,6 +104,9 @@
         "qs_pg:id":985482
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a8e8e8fc68291b937fccd67f1fac77c",
     "wof:hierarchy":[
         {
@@ -119,7 +122,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"Los Sauces",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/27/85765727.geojson
+++ b/data/857/657/27/85765727.geojson
@@ -94,6 +94,9 @@
         "qs_pg:id":352875
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20a3168f2c6339869a5c5d80cfff86fa",
     "wof:hierarchy":[
         {
@@ -109,7 +112,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"El Pino",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/31/85765731.geojson
+++ b/data/857/657/31/85765731.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1085665
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf3d898aeb61445496c2235c8f57bde3",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"Javier Prado",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/35/85765735.geojson
+++ b/data/857/657/35/85765735.geojson
@@ -100,6 +100,10 @@
         "qs_pg:id":236902
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b874aa9bfc714a8fd213c2b6a7e7f342",
     "wof:hierarchy":[
         {
@@ -115,7 +119,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Tupac Amaru",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/39/85765739.geojson
+++ b/data/857/657/39/85765739.geojson
@@ -128,6 +128,9 @@
         "qs_pg:id":223950
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"78c427a14fc912ce6bf2531baedcbb6e",
     "wof:hierarchy":[
         {
@@ -143,7 +146,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"Santa Catalina",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/41/85765741.geojson
+++ b/data/857/657/41/85765741.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":236903
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a926af6a210baf8649dd96c354c24bbd",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"Balconcillo",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/47/85765747.geojson
+++ b/data/857/657/47/85765747.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":236904
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8327b9eea26824d849cb62f2d994a2aa",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674472,
+    "wof:lastmodified":1582343476,
     "wof:name":"Santa Beatre",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/857/657/51/85765751.geojson
+++ b/data/857/657/51/85765751.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1329437
     },
     "wof:country":"PE",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cdadba943cf5684ff285ad6187d10d6",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "spa"
     ],
-    "wof:lastmodified":1566674471,
+    "wof:lastmodified":1582343476,
     "wof:name":"Cipreses",
     "wof:parent_id":421186805,
     "wof:placetype":"neighbourhood",

--- a/data/890/445/053/890445053.geojson
+++ b/data/890/445/053/890445053.geojson
@@ -313,6 +313,9 @@
     },
     "wof:country":"PE",
     "wof:created":1469052492,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69bf2539fa5d31d208a998d2e22dac2d",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
         }
     ],
     "wof:id":890445053,
-    "wof:lastmodified":1566676563,
+    "wof:lastmodified":1582343555,
     "wof:name":"Huaraz",
     "wof:parent_id":421187921,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.