### PR TITLE
pe concordances, placetype local, and more

### DIFF
--- a/data/110/869/388/3/1108693883.geojson
+++ b/data/110/869/388/3/1108693883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090897,
-    "geom:area_square_m":1112550245.829565,
+    "geom:area_square_m":1112550344.3506,
     "geom:bbox":"-78.682748,-8.387604,-78.288967,-7.989814",
     "geom:latitude":-8.172107,
     "geom:longitude":-78.463691,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.LL.JU",
         "wd:id":"Q1920491"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415216,
-    "wof:geomhash":"1282fc6d6064b90fe5c4abc45ab6ff14",
+    "wof:geomhash":"5855d88873b14cb66edc94c7bbeb8692",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108693883,
-    "wof:lastmodified":1690850417,
+    "wof:lastmodified":1695886603,
     "wof:name":"Julc\u00e1n",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/110/869/388/5/1108693885.geojson
+++ b/data/110/869/388/5/1108693885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.21911,
-    "geom:area_square_m":2681788041.922769,
+    "geom:area_square_m":2681788455.375751,
     "geom:bbox":"-78.43001,-8.652947,-77.641113,-7.880643",
     "geom:latitude":-8.175933,
     "geom:longitude":-78.139315,
@@ -118,9 +118,10 @@
         "hasc:id":"PE.LL.SD",
         "wd:id":"Q1944238"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415221,
-    "wof:geomhash":"3373060bd2ec3ef7c3f174765cc26a45",
+    "wof:geomhash":"51bebcfba9170bdca7775e2b8ae16bbe",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108693885,
-    "wof:lastmodified":1690850417,
+    "wof:lastmodified":1695886603,
     "wof:name":"Santiago De Chuco",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/110/869/388/7/1108693887.geojson
+++ b/data/110/869/388/7/1108693887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.105528,
-    "geom:area_square_m":1293475237.48422,
+    "geom:area_square_m":1293475442.001718,
     "geom:bbox":"-78.944496,-7.797174,-78.323098,-7.394855",
     "geom:latitude":-7.579728,
     "geom:longitude":-78.647636,
@@ -133,9 +133,10 @@
         "hasc:id":"PE.LL.GC",
         "wd:id":"Q1920564"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415225,
-    "wof:geomhash":"916e93fd2029bb7a5532b2a4af6161cd",
+    "wof:geomhash":"209e0ebbbc3d32b4101d831b25ccb534",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108693887,
-    "wof:lastmodified":1690850417,
+    "wof:lastmodified":1695886603,
     "wof:name":"Gran Chim\u00fa",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/110/869/388/9/1108693889.geojson
+++ b/data/110/869/388/9/1108693889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.647873,
-    "geom:area_square_m":19991129764.41647,
+    "geom:area_square_m":19991125209.944839,
     "geom:bbox":"-72.18209,-11.931666,-68.969887,-9.906908",
     "geom:latitude":-11.15141,
     "geom:longitude":-70.328372,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.MD.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415238,
-    "wof:geomhash":"92d386bf2b13030464aa3bb4e7183293",
+    "wof:geomhash":"174b0758a3d975509aa68395de6b5786",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108693889,
-    "wof:lastmodified":1627522497,
+    "wof:lastmodified":1695886135,
     "wof:name":"Tahuamanu",
     "wof:parent_id":85675847,
     "wof:placetype":"county",

--- a/data/110/869/389/1/1108693891.geojson
+++ b/data/110/869/389/1/1108693891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.988628,
-    "geom:area_square_m":36118574710.711143,
+    "geom:area_square_m":36118572952.919571,
     "geom:bbox":"-72.217666,-13.341852,-68.652288,-11.033732",
     "geom:latitude":-12.199731,
     "geom:longitude":-70.049496,
@@ -71,9 +71,10 @@
     "wof:concordances":{
         "hasc:id":"PE.MD.TP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415239,
-    "wof:geomhash":"4fa129d068d1cfb86be63c2eef292134",
+    "wof:geomhash":"1821841f27f6b1e12f4fc5a3911195a6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -83,7 +84,7 @@
         }
     ],
     "wof:id":1108693891,
-    "wof:lastmodified":1627522497,
+    "wof:lastmodified":1695886136,
     "wof:name":"Tambopata",
     "wof:parent_id":85675847,
     "wof:placetype":"county",

--- a/data/110/869/389/3/1108693893.geojson
+++ b/data/110/869/389/3/1108693893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.520438,
-    "geom:area_square_m":18492905074.834877,
+    "geom:area_square_m":18492903445.311676,
     "geom:bbox":"-72.484771,-11.012986,-70.493962,-9.423746",
     "geom:latitude":-10.373108,
     "geom:longitude":-71.58239,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.UC.PU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415246,
-    "wof:geomhash":"810d4c9e52d547f1b39e55957f751ca1",
+    "wof:geomhash":"40c19ae2b892b48d43c9ad3049cd8cad",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108693893,
-    "wof:lastmodified":1627522496,
+    "wof:lastmodified":1695886134,
     "wof:name":"Pur\u00fas",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/110/869/389/5/1108693895.geojson
+++ b/data/110/869/389/5/1108693895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243299,
-    "geom:area_square_m":2989398653.29491,
+    "geom:area_square_m":2989398423.837512,
     "geom:bbox":"-78.038154,-6.98658,-77.469535,-5.942559",
     "geom:latitude":-6.442966,
     "geom:longitude":-77.77541,
@@ -138,9 +138,10 @@
         "hasc:id":"PE.AM.CP",
         "wd:id":"Q997406"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415247,
-    "wof:geomhash":"126b59e77d474b9314e8dfc98b9cd50d",
+    "wof:geomhash":"5ede214d70b886cfec4f1ba389f2f58e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108693895,
-    "wof:lastmodified":1690850416,
+    "wof:lastmodified":1695886747,
     "wof:name":"Chachapoyas",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/110/869/389/7/1108693897.geojson
+++ b/data/110/869/389/7/1108693897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.211158,
-    "geom:area_square_m":2594863925.962112,
+    "geom:area_square_m":2594863834.316854,
     "geom:bbox":"-77.753082,-6.725277,-77.132844,-6.000168",
     "geom:latitude":-6.372973,
     "geom:longitude":-77.454828,
@@ -127,9 +127,10 @@
         "hasc:id":"PE.AM.RM",
         "wd:id":"Q1366038"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415250,
-    "wof:geomhash":"cb3f3bd7d2c54170eaab5d1eb6518420",
+    "wof:geomhash":"17ae16542b43e35990815653a1c3688f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108693897,
-    "wof:lastmodified":1690850416,
+    "wof:lastmodified":1695886603,
     "wof:name":"Rodriguez De Mendoza",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/110/869/390/1/1108693901.geojson
+++ b/data/110/869/390/1/1108693901.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.471829,
-    "geom:area_square_m":5811281508.224758,
+    "geom:area_square_m":5811281508.226628,
     "geom:bbox":"-78.7106699219,-5.72444726562,-78.057,-4.50077027246",
     "geom:latitude":-5.078686,
     "geom:longitude":-78.400681,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AM.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415252,
-    "wof:geomhash":"0464618e415bfd92e00f0edecd7bc17b",
+    "wof:geomhash":"cb20ff7fc7c18907427a5419a4801d0d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108693901,
-    "wof:lastmodified":1566675936,
+    "wof:lastmodified":1695886596,
     "wof:name":"Bagua",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/110/869/390/3/1108693903.geojson
+++ b/data/110/869/390/3/1108693903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.447791,
-    "geom:area_square_m":5361479523.643185,
+    "geom:area_square_m":5361479615.89269,
     "geom:bbox":"-72.503922,-14.887891,-71.514609,-13.934609",
     "geom:latitude":-14.464412,
     "geom:longitude":-72.011361,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.CS.CI",
         "wd:id":"Q584864"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415261,
-    "wof:geomhash":"0871f866c4cf0fc5a73a9dfd11387a43",
+    "wof:geomhash":"4cb013c5bb90ac635cd0c456cbd55ea0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108693903,
-    "wof:lastmodified":1690850407,
+    "wof:lastmodified":1695886596,
     "wof:name":"Chumbivilcas",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/110/869/390/5/1108693905.geojson
+++ b/data/110/869/390/5/1108693905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178185,
-    "geom:area_square_m":2137264605.831353,
+    "geom:area_square_m":2137264856.788278,
     "geom:bbox":"-72.902344,-14.362021,-72.34941,-13.73026",
     "geom:latitude":-14.061156,
     "geom:longitude":-72.622472,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.AP.GR",
         "wd:id":"Q1814172"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415264,
-    "wof:geomhash":"c251cb33074cbf9665ec10305f721cab",
+    "wof:geomhash":"47fb7e627e6abdc708628587a8afea52",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693905,
-    "wof:lastmodified":1690850408,
+    "wof:lastmodified":1695886596,
     "wof:name":"Grau",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/110/869/390/7/1108693907.geojson
+++ b/data/110/869/390/7/1108693907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.219313,
-    "geom:area_square_m":2631068021.10186,
+    "geom:area_square_m":2631067636.195096,
     "geom:bbox":"-72.48124,-14.440949,-72.050994,-13.642152",
     "geom:latitude":-14.018631,
     "geom:longitude":-72.269809,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AP.CO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415267,
-    "wof:geomhash":"08be94bd56fa6fa1e60aefa17ad584be",
+    "wof:geomhash":"5bfccda240240dbcc0928e8fff38c72f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108693907,
-    "wof:lastmodified":1627522496,
+    "wof:lastmodified":1695886135,
     "wof:name":"Cotabambas",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/110/869/390/9/1108693909.geojson
+++ b/data/110/869/390/9/1108693909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.269953,
-    "geom:area_square_m":3232600281.421615,
+    "geom:area_square_m":3232600157.289634,
     "geom:bbox":"-73.082711,-14.759877,-72.338227,-14.107387",
     "geom:latitude":-14.437287,
     "geom:longitude":-72.736612,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AP.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415271,
-    "wof:geomhash":"35566894b2fcc1ebbc03d7f5df5d5aea",
+    "wof:geomhash":"9f9c8e591b8bf86750b0ea631db9e1b5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693909,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886129,
     "wof:name":"Antabamba",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/110/869/391/1/1108693911.geojson
+++ b/data/110/869/391/1/1108693911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125817,
-    "geom:area_square_m":1529660770.758065,
+    "geom:area_square_m":1529660720.350564,
     "geom:bbox":"-76.730492,-10.747715,-76.236916,-10.285992",
     "geom:latitude":-10.508668,
     "geom:longitude":-76.482386,
@@ -126,9 +126,10 @@
         "hasc:id":"PE.PA.DA",
         "wd:id":"Q1944288"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415272,
-    "wof:geomhash":"c9de781954ec1d27a1958c9a29bef9f3",
+    "wof:geomhash":"eae85ecc3546079bc86749412ea8a5ad",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108693911,
-    "wof:lastmodified":1690850406,
+    "wof:lastmodified":1695886594,
     "wof:name":"Daniel Alcides Carri\u00f3n",
     "wof:parent_id":85675883,
     "wof:placetype":"county",

--- a/data/110/869/391/3/1108693913.geojson
+++ b/data/110/869/391/3/1108693913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.060042,
-    "geom:area_square_m":12726165662.370972,
+    "geom:area_square_m":12726165507.181557,
     "geom:bbox":"-69.853531,-14.662004,-68.826675,-13.003803",
     "geom:latitude":-13.851168,
     "geom:longitude":-69.32557,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.PU.SN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415276,
-    "wof:geomhash":"38eabeeab23cc88f99bd651d9cf7c614",
+    "wof:geomhash":"1f2ab3e79e5942aba7ca8a4d002d7e12",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693913,
-    "wof:lastmodified":1627522497,
+    "wof:lastmodified":1695886137,
     "wof:name":"Sandia",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/110/869/391/5/1108693915.geojson
+++ b/data/110/869/391/5/1108693915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.43928,
-    "geom:area_square_m":5251084765.791853,
+    "geom:area_square_m":5251085016.018863,
     "geom:bbox":"-70.468178,-15.402818,-69.836227,-14.2679",
     "geom:latitude":-14.81786,
     "geom:longitude":-70.143292,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"PE.PU.AZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415279,
-    "wof:geomhash":"4833f2283722f9f0af8a67f29cde4a42",
+    "wof:geomhash":"9de2e2d817e6d4926e7759a41cb02837",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108693915,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886129,
     "wof:name":"Az\u00e1ngaro",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/110/869/391/9/1108693919.geojson
+++ b/data/110/869/391/9/1108693919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.47675,
-    "geom:area_square_m":5645489569.978541,
+    "geom:area_square_m":5645489895.749379,
     "geom:bbox":"-70.147461,-17.295395,-69.422222,-15.913072",
     "geom:latitude":-16.73003,
     "geom:longitude":-69.756161,
@@ -126,9 +126,10 @@
         "hasc:id":"PE.PU.EC",
         "wd:id":"Q2088833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415282,
-    "wof:geomhash":"2e6d4d647198d2f73918ac1adbf1e633",
+    "wof:geomhash":"c00fcd92bf98e4e6c0aaead69b1f12bc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108693919,
-    "wof:lastmodified":1690850405,
+    "wof:lastmodified":1695886594,
     "wof:name":"El Collao",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/110/869/392/1/1108693921.geojson
+++ b/data/110/869/392/1/1108693921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.262771,
-    "geom:area_square_m":3142678966.135388,
+    "geom:area_square_m":3142679637.284323,
     "geom:bbox":"-70.011826,-15.111375,-69.11329,-14.305566",
     "geom:latitude":-14.711963,
     "geom:longitude":-69.615718,
@@ -124,9 +124,10 @@
         "hasc:id":"PE.PU.SA",
         "wd:id":"Q1935565"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415289,
-    "wof:geomhash":"d9e35dd82c0ef3fbd0a09f2ae4389bd8",
+    "wof:geomhash":"685dd301a35e72ae205936217acb5bf3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108693921,
-    "wof:lastmodified":1690850409,
+    "wof:lastmodified":1695886598,
     "wof:name":"San Antonio De Putina",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/110/869/392/3/1108693923.geojson
+++ b/data/110/869/392/3/1108693923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.259992,
-    "geom:area_square_m":3171824217.911322,
+    "geom:area_square_m":3171824007.345185,
     "geom:bbox":"-77.048523,-9.760256,-76.057045,-9.053592",
     "geom:latitude":-9.384167,
     "geom:longitude":-76.60214,
@@ -126,9 +126,10 @@
         "hasc:id":"PE.HC.HE",
         "wd:id":"Q1819840"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415301,
-    "wof:geomhash":"757ad73797ebc5e3ba3454f98eaa251b",
+    "wof:geomhash":"5b68808db84ef5383cf21f048efb17c0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -138,7 +139,7 @@
         }
     ],
     "wof:id":1108693923,
-    "wof:lastmodified":1690850410,
+    "wof:lastmodified":1695886598,
     "wof:name":"Huamal\u00edes",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/110/869/392/5/1108693925.geojson
+++ b/data/110/869/392/5/1108693925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.139544,
-    "geom:area_square_m":1704268891.663782,
+    "geom:area_square_m":1704269107.032247,
     "geom:bbox":"-77.178322,-9.238437,-76.273713,-8.767615",
     "geom:latitude":-8.994885,
     "geom:longitude":-76.812094,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"PE.HC.HC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415303,
-    "wof:geomhash":"77617186a9fddd4c9841d07d87c5fb9b",
+    "wof:geomhash":"eef26c76b14e6dabc6bdf7a22a8c7182",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108693925,
-    "wof:lastmodified":1627522494,
+    "wof:lastmodified":1695886131,
     "wof:name":"Huacaybamba",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/110/869/392/7/1108693927.geojson
+++ b/data/110/869/392/7/1108693927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.407239,
-    "geom:area_square_m":4977341313.736217,
+    "geom:area_square_m":4977341319.587146,
     "geom:bbox":"-77.316818,-9.051496,-76.190934,-8.410598",
     "geom:latitude":-8.72193,
     "geom:longitude":-76.691551,
@@ -123,9 +123,10 @@
         "hasc:id":"PE.HC.MA",
         "wd:id":"Q764487"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415307,
-    "wof:geomhash":"e4674fb48e2a78d7d557dacca7f80dfc",
+    "wof:geomhash":"2c6d1cc352fde2369d92260640d9e4c0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":1108693927,
-    "wof:lastmodified":1690850409,
+    "wof:lastmodified":1695886599,
     "wof:name":"Mara\u00f1\u00f3n",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/110/869/392/9/1108693929.geojson
+++ b/data/110/869/392/9/1108693929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130282,
-    "geom:area_square_m":1585359733.822877,
+    "geom:area_square_m":1585359733.822846,
     "geom:bbox":"-76.5244746094,-10.4659160156,-76.0254824219,-9.982546875",
     "geom:latitude":-10.228577,
     "geom:longitude":-76.233534,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.HC.AO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415308,
-    "wof:geomhash":"4fc1e6ffd266dd6e3bdd8e6b5da49871",
+    "wof:geomhash":"49e89c9842162cd5c051541aca0cd918",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693929,
-    "wof:lastmodified":1566675940,
+    "wof:lastmodified":1695886598,
     "wof:name":"Ambo",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/110/869/393/1/1108693931.geojson
+++ b/data/110/869/393/1/1108693931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330074,
-    "geom:area_square_m":3974473383.92352,
+    "geom:area_square_m":3974473238.373069,
     "geom:bbox":"-75.810516,-13.525926,-74.989494,-12.774109",
     "geom:latitude":-13.145122,
     "geom:longitude":-75.406235,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.HV.CV",
         "wd:id":"Q1944312"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415314,
-    "wof:geomhash":"99a1297c2e8de530a9a371e2729cfeab",
+    "wof:geomhash":"d77d84139d539d1966461b992951e7e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693931,
-    "wof:lastmodified":1690850411,
+    "wof:lastmodified":1695886599,
     "wof:name":"Castrovirreyna",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/110/869/393/3/1108693933.geojson
+++ b/data/110/869/393/3/1108693933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.175041,
-    "geom:area_square_m":2089453747.490896,
+    "geom:area_square_m":2089453240.691375,
     "geom:bbox":"-73.555375,-15.40492,-72.982742,-14.825529",
     "geom:latitude":-15.122872,
     "geom:longitude":-73.261909,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.AY.PS",
         "wd:id":"Q1806437"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415318,
-    "wof:geomhash":"9915d186f206607daac882aa40fad6f1",
+    "wof:geomhash":"7a181b8652eb2745144152107371be43",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108693933,
-    "wof:lastmodified":1690850411,
+    "wof:lastmodified":1695886600,
     "wof:name":"Paucar Del Sara Sara",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/393/7/1108693937.geojson
+++ b/data/110/869/393/7/1108693937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.500365,
-    "geom:area_square_m":5975330090.894513,
+    "geom:area_square_m":5975330828.372789,
     "geom:bbox":"-74.2574,-15.629709,-72.846824,-14.506963",
     "geom:latitude":-15.032051,
     "geom:longitude":-73.634985,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.AY.PH",
         "wd:id":"Q549969"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415319,
-    "wof:geomhash":"2266e1c1c8a35743e77c7f34a8ba4042",
+    "wof:geomhash":"90b83bb7b316a5bbba5aebcfbb83dd58",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693937,
-    "wof:lastmodified":1690850410,
+    "wof:lastmodified":1695886599,
     "wof:name":"Parinacochas",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/393/9/1108693939.geojson
+++ b/data/110/869/393/9/1108693939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.237368,
-    "geom:area_square_m":2848598334.099598,
+    "geom:area_square_m":2848598891.000016,
     "geom:bbox":"-74.792617,-14.167062,-74.099229,-13.69582",
     "geom:latitude":-13.944458,
     "geom:longitude":-74.460071,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.AY.HS",
         "wd:id":"Q1808513"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415321,
-    "wof:geomhash":"5c4f4bd2828a378cf8550cac03b1b95b",
+    "wof:geomhash":"64dc92faa8c52f0845e7f3198feb6934",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693939,
-    "wof:lastmodified":1690850410,
+    "wof:lastmodified":1695886599,
     "wof:name":"Huanca Sancos",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/394/1/1108693941.geojson
+++ b/data/110/869/394/1/1108693941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.156347,
-    "geom:area_square_m":1879849348.818516,
+    "geom:area_square_m":1879849324.501195,
     "geom:bbox":"-74.90525,-13.68516,-74.035439,-13.324471",
     "geom:latitude":-13.49962,
     "geom:longitude":-74.486921,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AY.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415325,
-    "wof:geomhash":"f8336ef000aa4ee27ad3a2a52ec4c092",
+    "wof:geomhash":"fbb8294a5b19d5fcd3e0b9509d271482",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693941,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886129,
     "wof:name":"Cangallo",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/394/3/1108693943.geojson
+++ b/data/110/869/394/3/1108693943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100737,
-    "geom:area_square_m":1210424430.403708,
+    "geom:area_square_m":1210424171.697397,
     "geom:bbox":"-74.080346,-13.938437,-73.670021,-13.412496",
     "geom:latitude":-13.654365,
     "geom:longitude":-73.89901,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AY.VH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415327,
-    "wof:geomhash":"8d47b4895a76718a4050b2e5b61ce236",
+    "wof:geomhash":"e690528932e66d9bc44e36ed55a72f53",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108693943,
-    "wof:lastmodified":1627522498,
+    "wof:lastmodified":1695886137,
     "wof:name":"Vilcas Huam\u00e1n",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/394/5/1108693945.geojson
+++ b/data/110/869/394/5/1108693945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.18936,
-    "geom:area_square_m":2274001767.41952,
+    "geom:area_square_m":2274001767.420005,
     "geom:bbox":"-74.7831269531,-14.1868378906,-73.8639140625,-13.5558320312",
     "geom:latitude":-13.787525,
     "geom:longitude":-74.248938,
@@ -118,9 +118,10 @@
         "hasc:id":"PE.AY.VF",
         "wd:id":"Q1947116"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415328,
-    "wof:geomhash":"069c81540337e8bf8ac98e160fc8d61c",
+    "wof:geomhash":"a2c277e4e61beed80f9006f7d58902ab",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108693945,
-    "wof:lastmodified":1566675944,
+    "wof:lastmodified":1695886600,
     "wof:name":"Fajardo",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/394/7/1108693947.geojson
+++ b/data/110/869/394/7/1108693947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149582,
-    "geom:area_square_m":1793679423.851735,
+    "geom:area_square_m":1793679619.379021,
     "geom:bbox":"-73.989234,-14.416523,-73.51143,-13.763477",
     "geom:latitude":-14.124866,
     "geom:longitude":-73.732032,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.AY.SU",
         "wd:id":"Q1814180"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415330,
-    "wof:geomhash":"638e2902e2e4e9723e152270d78a5373",
+    "wof:geomhash":"0c398cb6e05a77ee11c9b8dea96a5e97",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108693947,
-    "wof:lastmodified":1690850411,
+    "wof:lastmodified":1695886746,
     "wof:name":"Sucre",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/110/869/394/9/1108693949.geojson
+++ b/data/110/869/394/9/1108693949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.126134,
-    "geom:area_square_m":1533480036.097014,
+    "geom:area_square_m":1533480089.906499,
     "geom:bbox":"-77.344834,-10.698109,-76.799896,-10.27009",
     "geom:latitude":-10.5155,
     "geom:longitude":-77.032547,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"PE.LR.CJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415331,
-    "wof:geomhash":"800f335524156b803c4a5676cbe6fc82",
+    "wof:geomhash":"0f9787d97db78f43c90c6a238c66a427",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108693949,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886130,
     "wof:name":"Cajatambo",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/395/1/1108693951.geojson
+++ b/data/110/869/395/1/1108693951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.154651,
-    "geom:area_square_m":1878675225.669549,
+    "geom:area_square_m":1878674661.197656,
     "geom:bbox":"-77.196229,-11.016459,-76.588195,-10.419127",
     "geom:latitude":-10.758847,
     "geom:longitude":-76.876549,
@@ -133,9 +133,10 @@
         "hasc:id":"PE.LR.OY",
         "wd:id":"Q1422624"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415333,
-    "wof:geomhash":"1e1659d9e4bce24cd71f63c843e05b98",
+    "wof:geomhash":"6dda9e76e25b7ed7eba784c5db191297",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108693951,
-    "wof:lastmodified":1690850409,
+    "wof:lastmodified":1695886598,
     "wof:name":"Oy\u00f3n",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/395/5/1108693955.geojson
+++ b/data/110/869/395/5/1108693955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.581352,
-    "geom:area_square_m":7017655355.620608,
+    "geom:area_square_m":7017655808.512787,
     "geom:bbox":"-76.367156,-13.06043,-75.508172,-11.983426",
     "geom:latitude":-12.515146,
     "geom:longitude":-75.902364,
@@ -95,9 +95,10 @@
     "wof:concordances":{
         "hasc:id":"PE.LR.YY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415334,
-    "wof:geomhash":"766b161251e3b537e3c6e5474ad519f1",
+    "wof:geomhash":"31a12744ebeeefe6ff8a0760b8f0775c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108693955,
-    "wof:lastmodified":1627522498,
+    "wof:lastmodified":1695886138,
     "wof:name":"Yauyos",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/395/7/1108693957.geojson
+++ b/data/110/869/395/7/1108693957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.376152,
-    "geom:area_square_m":4535661675.121808,
+    "geom:area_square_m":4535662205.030663,
     "geom:bbox":"-76.790855,-13.323489,-75.940674,-12.275729",
     "geom:latitude":-12.794451,
     "geom:longitude":-76.362363,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.LR.CT",
         "wd:id":"Q1431156"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415336,
-    "wof:geomhash":"b88d2354b17bda73958fb2e37a02f72f",
+    "wof:geomhash":"f20f72540f4b3816ff873838166a22fc",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693957,
-    "wof:lastmodified":1690850408,
+    "wof:lastmodified":1695886597,
     "wof:name":"Ca\u00f1ete",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/395/9/1108693959.geojson
+++ b/data/110/869/395/9/1108693959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113714,
-    "geom:area_square_m":1381793327.456518,
+    "geom:area_square_m":1381793327.456539,
     "geom:bbox":"-77.8863114417,-10.9321171875,-77.3656542969,-10.3209023437",
     "geom:latitude":-10.666259,
     "geom:longitude":-77.657015,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.LR.BR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415337,
-    "wof:geomhash":"1c86c37efd99023626b05e130ee391cd",
+    "wof:geomhash":"5f0d13f826d39b4ae98625a5bd2caba0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108693959,
-    "wof:lastmodified":1566675939,
+    "wof:lastmodified":1695886597,
     "wof:name":"Barranca",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/396/1/1108693961.geojson
+++ b/data/110/869/396/1/1108693961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.407141,
-    "geom:area_square_m":4941293394.940744,
+    "geom:area_square_m":4941293749.330337,
     "geom:bbox":"-77.700099,-11.447192,-76.564957,-10.606994",
     "geom:latitude":-11.03354,
     "geom:longitude":-77.237753,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"PE.LR.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415340,
-    "wof:geomhash":"f3110e5184cceb50b673ef786f9339a2",
+    "wof:geomhash":"2fd3fb3ade302c946e4104a2f03fa8c7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108693961,
-    "wof:lastmodified":1636500220,
+    "wof:lastmodified":1695886744,
     "wof:name":"Huaura",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/396/3/1108693963.geojson
+++ b/data/110/869/396/3/1108693963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.302831,
-    "geom:area_square_m":3671673636.4026,
+    "geom:area_square_m":3671673502.507954,
     "geom:bbox":"-77.382654,-11.678322,-76.457023,-11.013484",
     "geom:latitude":-11.32268,
     "geom:longitude":-76.913097,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.LR.HR",
         "wd:id":"Q1422606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415341,
-    "wof:geomhash":"378344b206161b094582bc1489b031fc",
+    "wof:geomhash":"3b2a9a3d02f5732e5f26cd2b3ccae231",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108693963,
-    "wof:lastmodified":1690850406,
+    "wof:lastmodified":1695886594,
     "wof:name":"Huaral",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/396/5/1108693965.geojson
+++ b/data/110/869/396/5/1108693965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14033,
-    "geom:area_square_m":1700123168.869085,
+    "geom:area_square_m":1700123230.28824,
     "geom:bbox":"-77.035332,-11.756705,-76.37185,-11.312379",
     "geom:latitude":-11.540932,
     "geom:longitude":-76.710008,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"PE.LR.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415344,
-    "wof:geomhash":"0ceebe3cb70067b8b1ec53a18a5e53fb",
+    "wof:geomhash":"69912cdab9ce52fb1bda80a11b4a574b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108693965,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886130,
     "wof:name":"Canta",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/396/7/1108693967.geojson
+++ b/data/110/869/396/7/1108693967.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.476131,
-    "geom:area_square_m":5760043311.297932,
+    "geom:area_square_m":5760042647.64372,
     "geom:bbox":"-76.942275,-12.409795,-75.993805,-11.457805",
     "geom:latitude":-11.939806,
     "geom:longitude":-76.425589,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.LR.HH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415345,
-    "wof:geomhash":"a1facdb3a807dbf67dbbe6f64a8a7282",
+    "wof:geomhash":"494272d48ca37f20102347b388f4ac53",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108693967,
-    "wof:lastmodified":1627522494,
+    "wof:lastmodified":1695886131,
     "wof:name":"Huarochir\u00ed",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/110/869/396/9/1108693969.geojson
+++ b/data/110/869/396/9/1108693969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.428039,
-    "geom:area_square_m":5275820247.875111,
+    "geom:area_square_m":5275820227.794271,
     "geom:bbox":"-80.968258,-5.298361,-80.201947,-4.081778",
     "geom:latitude":-4.582316,
     "geom:longitude":-80.637718,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.PI.SL",
         "wd:id":"Q612923"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415350,
-    "wof:geomhash":"5e1a8fc6096e60b2744de7e2e1898393",
+    "wof:geomhash":"1c26fc369b5ecfb0120691349ca5391f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108693969,
-    "wof:lastmodified":1690850406,
+    "wof:lastmodified":1695886744,
     "wof:name":"Sullana",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/110/869/397/3/1108693973.geojson
+++ b/data/110/869/397/3/1108693973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.142332,
-    "geom:area_square_m":1753090750.786836,
+    "geom:area_square_m":1753090939.010425,
     "geom:bbox":"-81.210555,-5.388461,-80.824818,-4.771793",
     "geom:latitude":-5.061769,
     "geom:longitude":-81.005301,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"PE.PI.PT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415351,
-    "wof:geomhash":"fe4bcb7aa29e4614eb86be911ac6b111",
+    "wof:geomhash":"cea2978f996fe7785177d287b19a46b4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108693973,
-    "wof:lastmodified":1636500221,
+    "wof:lastmodified":1695886745,
     "wof:name":"Paita",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/110/869/397/5/1108693975.geojson
+++ b/data/110/869/397/5/1108693975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501233,
-    "geom:area_square_m":6172118489.665494,
+    "geom:area_square_m":6172118489.663754,
     "geom:bbox":"-80.9702304687,-5.81105664062,-79.9685390625,-4.58510742187",
     "geom:latitude":-5.213994,
     "geom:longitude":-80.402982,
@@ -194,9 +194,10 @@
     "wof:concordances":{
         "hasc:id":"PE.PI.PR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415357,
-    "wof:geomhash":"6bffae548c3f166ae10cbed5013c91e9",
+    "wof:geomhash":"9043d8ae35c41fa7cc6d2c563069c963",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":1108693975,
-    "wof:lastmodified":1566675935,
+    "wof:lastmodified":1695886595,
     "wof:name":"Piura",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/110/869/397/7/1108693977.geojson
+++ b/data/110/869/397/7/1108693977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.247794,
-    "geom:area_square_m":3046240298.300465,
+    "geom:area_square_m":3046240298.300172,
     "geom:bbox":"-79.2748574219,-6.54984960937,-78.5074394531,-5.77752734375",
     "geom:latitude":-6.173696,
     "geom:longitude":-78.839208,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415359,
-    "wof:geomhash":"628a61a2fd7c11fd49c150ad11174c22",
+    "wof:geomhash":"1d3e68f2596093b7d0aad0c13aa4db03",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1108693977,
-    "wof:lastmodified":1566675935,
+    "wof:lastmodified":1695886595,
     "wof:name":"Cutervo",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/397/9/1108693979.geojson
+++ b/data/110/869/397/9/1108693979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064174,
-    "geom:area_square_m":788094038.144182,
+    "geom:area_square_m":788094199.374187,
     "geom:bbox":"-78.77024,-6.867627,-78.385094,-6.560479",
     "geom:latitude":-6.709628,
     "geom:longitude":-78.545982,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.HG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415361,
-    "wof:geomhash":"86215e71ce7358203a794f53d549adb8",
+    "wof:geomhash":"eb00f863c29d60418ca83411eab382c6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108693979,
-    "wof:lastmodified":1627522494,
+    "wof:lastmodified":1695886131,
     "wof:name":"Hualgayoc",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/398/1/1108693981.geojson
+++ b/data/110/869/398/1/1108693981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05443,
-    "geom:area_square_m":667906407.804294,
+    "geom:area_square_m":667906602.323415,
     "geom:bbox":"-78.918984,-7.228129,-78.598068,-6.852053",
     "geom:latitude":-7.074808,
     "geom:longitude":-78.749318,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.SP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415363,
-    "wof:geomhash":"14b1c5deddecdb97b505f1d44ac85691",
+    "wof:geomhash":"a38f077cb69331185a4b5c11d1e42191",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108693981,
-    "wof:lastmodified":1636500220,
+    "wof:lastmodified":1695886744,
     "wof:name":"San Pablo",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/398/3/1108693983.geojson
+++ b/data/110/869/398/3/1108693983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113135,
-    "geom:area_square_m":1389431518.167672,
+    "geom:area_square_m":1389431460.361097,
     "geom:bbox":"-79.248283,-6.874203,-78.718414,-6.504057",
     "geom:latitude":-6.68389,
     "geom:longitude":-78.982931,
@@ -218,9 +218,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415364,
-    "wof:geomhash":"1b9c4743098a65adc906a111be9dc2ed",
+    "wof:geomhash":"212c401ce5e25c58234c4631ac132d74",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -230,7 +231,7 @@
         }
     ],
     "wof:id":1108693983,
-    "wof:lastmodified":1636500220,
+    "wof:lastmodified":1695886744,
     "wof:name":"Santa Cruz",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/398/5/1108693985.geojson
+++ b/data/110/869/398/5/1108693985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.207418,
-    "geom:area_square_m":2545768397.076395,
+    "geom:area_square_m":2545768053.829671,
     "geom:bbox":"-79.331848,-7.253238,-78.613121,-6.692711",
     "geom:latitude":-6.97733,
     "geom:longitude":-78.998185,
@@ -179,9 +179,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415366,
-    "wof:geomhash":"d52e9e947a0b43d375c65c86adb9dc8b",
+    "wof:geomhash":"3eafc04f87477029f266eae547d91b36",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":1108693985,
-    "wof:lastmodified":1636500221,
+    "wof:lastmodified":1695886745,
     "wof:name":"San Miguel",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/398/7/1108693987.geojson
+++ b/data/110/869/398/7/1108693987.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.30717,
-    "geom:area_square_m":3774275524.385858,
+    "geom:area_square_m":3774275711.409679,
     "geom:bbox":"-79.458443,-6.680779,-78.278793,-6.086248",
     "geom:latitude":-6.436206,
     "geom:longitude":-78.872804,
@@ -128,9 +128,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.CH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415372,
-    "wof:geomhash":"187d6682899601eed4abb5687fa7e08c",
+    "wof:geomhash":"169c6b03b5cea8247b0f614fc6a19417",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108693987,
-    "wof:lastmodified":1636500220,
+    "wof:lastmodified":1695886744,
     "wof:name":"Chota",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/399/1/1108693991.geojson
+++ b/data/110/869/399/1/1108693991.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110847,
-    "geom:area_square_m":1359582899.057955,
+    "geom:area_square_m":1359583147.294257,
     "geom:bbox":"-78.325652,-7.480562,-77.829605,-7.064924",
     "geom:latitude":-7.282883,
     "geom:longitude":-78.060862,
@@ -146,9 +146,10 @@
     "wof:concordances":{
         "hasc:id":"PE.CJ.SS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415373,
-    "wof:geomhash":"668fc4dc06a41b786e6dd606b4146489",
+    "wof:geomhash":"7209b3479fa92ca2e6707fdaace1d0dd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108693991,
-    "wof:lastmodified":1636500221,
+    "wof:lastmodified":1695886745,
     "wof:name":"San Marcos",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/399/3/1108693993.geojson
+++ b/data/110/869/399/3/1108693993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.661205,
-    "geom:area_square_m":8103175635.801196,
+    "geom:area_square_m":8103175635.798168,
     "geom:bbox":"-76.7362070312,-8.37993945312,-75.8302695312,-6.725671875",
     "geom:latitude":-7.638825,
     "geom:longitude":-76.319202,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"PE.SM.BV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415375,
-    "wof:geomhash":"1462de9cc1cc42bb2653471f9d43e7be",
+    "wof:geomhash":"1bdcd9ed7a1be8a940de0eeeed40c0b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108693993,
-    "wof:lastmodified":1566675933,
+    "wof:lastmodified":1695886595,
     "wof:name":"Bellavista",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/399/5/1108693995.geojson
+++ b/data/110/869/399/5/1108693995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198041,
-    "geom:area_square_m":2431786948.605226,
+    "geom:area_square_m":2431786721.958453,
     "geom:bbox":"-77.28707,-7.175266,-76.626678,-6.326592",
     "geom:latitude":-6.757703,
     "geom:longitude":-76.900955,
@@ -156,9 +156,10 @@
         "hasc:id":"PE.SM.HL",
         "wd:id":"Q731515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415378,
-    "wof:geomhash":"ade048f167b608c5b5cd49222d447512",
+    "wof:geomhash":"33e6852137398abfa6faba079aceed4a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":1108693995,
-    "wof:lastmodified":1690850407,
+    "wof:lastmodified":1695886745,
     "wof:name":"Huallaga",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/399/7/1108693997.geojson
+++ b/data/110/869/399/7/1108693997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108953,
-    "geom:area_square_m":1338408463.733526,
+    "geom:area_square_m":1338408260.390215,
     "geom:bbox":"-76.970504,-6.810279,-76.523072,-6.264254",
     "geom:latitude":-6.558576,
     "geom:longitude":-76.741386,
@@ -147,9 +147,10 @@
         "hasc:id":"PE.SM.ED",
         "wd:id":"Q2084675"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415380,
-    "wof:geomhash":"bb9750d9a23fac926213ba2049d5d9c2",
+    "wof:geomhash":"ed914afd232cd6eb56d6069e17b564e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108693997,
-    "wof:lastmodified":1690850407,
+    "wof:lastmodified":1695886745,
     "wof:name":"El Dorado",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/399/9/1108693999.geojson
+++ b/data/110/869/399/9/1108693999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173826,
-    "geom:area_square_m":2133817793.406317,
+    "geom:area_square_m":2133817795.566136,
     "geom:bbox":"-76.549668,-7.204984,-76.005059,-6.676705",
     "geom:latitude":-6.901117,
     "geom:longitude":-76.255475,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"PE.SM.PC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415382,
-    "wof:geomhash":"e7727eb47f7562fcaaebeade15f5d516",
+    "wof:geomhash":"ebe6cc9d279f6bc755d79043a2a150f7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1108693999,
-    "wof:lastmodified":1627522496,
+    "wof:lastmodified":1695886135,
     "wof:name":"Picota",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/400/1/1108694001.geojson
+++ b/data/110/869/400/1/1108694001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169472,
-    "geom:area_square_m":2073504864.976186,
+    "geom:area_square_m":2073504816.075199,
     "geom:bbox":"-78.236076,-8.695773,-77.557945,-8.051141",
     "geom:latitude":-8.317476,
     "geom:longitude":-77.901919,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.PL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415383,
-    "wof:geomhash":"aa130b92e405e31ae2f511be66a63cda",
+    "wof:geomhash":"563fd8b58e4fbb6e75cef370232841c5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694001,
-    "wof:lastmodified":1627522496,
+    "wof:lastmodified":1695886135,
     "wof:name":"Pallasca",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/400/3/1108694003.geojson
+++ b/data/110/869/400/3/1108694003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150102,
-    "geom:area_square_m":1824959968.827506,
+    "geom:area_square_m":1824959968.827616,
     "geom:bbox":"-77.74578125,-10.7887753906,-77.158828125,-10.2528222656",
     "geom:latitude":-10.498989,
     "geom:longitude":-77.429666,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.OC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415387,
-    "wof:geomhash":"4df7de41b57566ba46df6c477ed27569",
+    "wof:geomhash":"56436c2cbbd0a5539e5c2ceb7037e5c3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108694003,
-    "wof:lastmodified":1566675939,
+    "wof:lastmodified":1695886598,
     "wof:name":"Ocros",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/400/5/1108694005.geojson
+++ b/data/110/869/400/5/1108694005.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051551,
-    "geom:area_square_m":629506734.808733,
+    "geom:area_square_m":629506741.290832,
     "geom:bbox":"-77.366516,-9.208582,-77.10302,-8.8959",
     "geom:latitude":-9.044349,
     "geom:longitude":-77.242469,
@@ -138,9 +138,10 @@
         "hasc:id":"PE.AN.CF",
         "wd:id":"Q633478"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415389,
-    "wof:geomhash":"cc879ddd2a7fb253bb8062148579d79a",
+    "wof:geomhash":"35aa7690786dbaffa21ff88124d240b9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108694005,
-    "wof:lastmodified":1690850408,
+    "wof:lastmodified":1695886598,
     "wof:name":"Carlos F. Fitzcarrald",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/400/9/1108694009.geojson
+++ b/data/110/869/400/9/1108694009.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.267607,
-    "geom:area_square_m":3257574435.674525,
+    "geom:area_square_m":3257574435.674741,
     "geom:bbox":"-77.6998671875,-10.4825390625,-76.807046875,-9.70266796875",
     "geom:latitude":-10.114713,
     "geom:longitude":-77.157976,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.BO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415393,
-    "wof:geomhash":"dc70b268bc63e309cf1eeea5e3981962",
+    "wof:geomhash":"acf56ca07f512ff76548605ed8c7cf5f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108694009,
-    "wof:lastmodified":1566675938,
+    "wof:lastmodified":1695886597,
     "wof:name":"Bolognesi",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/401/1/1108694011.geojson
+++ b/data/110/869/401/1/1108694011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.083473,
-    "geom:area_square_m":1020639862.90747,
+    "geom:area_square_m":1020639862.90719,
     "geom:bbox":"-78.1310488281,-8.74728515625,-77.6903984375,-8.37865820312",
     "geom:latitude":-8.567785,
     "geom:longitude":-77.882135,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.CG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415395,
-    "wof:geomhash":"34c1b9543ddc4b87262d0de9aa7f0851",
+    "wof:geomhash":"3f561353022425bec8b3fbd87ccb19ec",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108694011,
-    "wof:lastmodified":1566675938,
+    "wof:lastmodified":1695886597,
     "wof:name":"Corongo",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/401/3/1108694013.geojson
+++ b/data/110/869/401/3/1108694013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119487,
-    "geom:area_square_m":1461308490.528302,
+    "geom:area_square_m":1461308490.52826,
     "geom:bbox":"-77.798859375,-8.75769140625,-77.3660507812,-8.2365390625",
     "geom:latitude":-8.484534,
     "geom:longitude":-77.585434,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415396,
-    "wof:geomhash":"05e015f3b2326d1004eb057b79897b0f",
+    "wof:geomhash":"cac74cff74c482e851b5e7267ffea77f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108694013,
-    "wof:lastmodified":1566675938,
+    "wof:lastmodified":1695886597,
     "wof:name":"Sihuas",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/401/5/1108694015.geojson
+++ b/data/110/869/401/5/1108694015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.075794,
-    "geom:area_square_m":926372699.430744,
+    "geom:area_square_m":926372699.431036,
     "geom:bbox":"-77.6081855469,-8.9237890625,-77.2467871094,-8.507703125",
     "geom:latitude":-8.720775,
     "geom:longitude":-77.435841,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.PB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415398,
-    "wof:geomhash":"8513c3c5d2aef29edf9eaf9e9d799124",
+    "wof:geomhash":"2596195b968f77666ca795a2b240c148",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108694015,
-    "wof:lastmodified":1566675938,
+    "wof:lastmodified":1695886597,
     "wof:name":"Pomabamba",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/401/7/1108694017.geojson
+++ b/data/110/869/401/7/1108694017.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046076,
-    "geom:area_square_m":562519152.159599,
+    "geom:area_square_m":562518999.795782,
     "geom:bbox":"-77.174697,-9.300727,-76.941414,-8.972129",
     "geom:latitude":-9.132294,
     "geom:longitude":-77.053466,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415399,
-    "wof:geomhash":"476538fece425b1b18b890b866c5d3af",
+    "wof:geomhash":"33a278fc7dde5d3f271a548e450cfee3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108694017,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886130,
     "wof:name":"Antonio Raymondi",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/401/9/1108694019.geojson
+++ b/data/110/869/401/9/1108694019.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186826,
-    "geom:area_square_m":2278551559.430544,
+    "geom:area_square_m":2278551891.103606,
     "geom:bbox":"-78.433729,-9.794614,-77.900994,-9.201258",
     "geom:latitude":-9.484968,
     "geom:longitude":-78.186245,
@@ -134,9 +134,10 @@
     "wof:concordances":{
         "hasc:id":"PE.AN.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415403,
-    "wof:geomhash":"e1e676044ee8205488d4a8a14bbfb332",
+    "wof:geomhash":"308b7d2e53007eabc7b93d0cdedab035",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108694019,
-    "wof:lastmodified":1636500222,
+    "wof:lastmodified":1695886746,
     "wof:name":"Casma",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/110/869/402/1/1108694021.geojson
+++ b/data/110/869/402/1/1108694021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.242194,
-    "geom:area_square_m":2914230356.52951,
+    "geom:area_square_m":2914230523.302143,
     "geom:bbox":"-76.244803,-13.631816,-75.60324,-12.964889",
     "geom:latitude":-13.317888,
     "geom:longitude":-75.939423,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"PE.IC.CN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415406,
-    "wof:geomhash":"a67901b5544b77af453a9410211a1923",
+    "wof:geomhash":"4066636a2c3ddec7d3253064d9e28060",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1108694021,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886130,
     "wof:name":"Chincha",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/110/869/402/3/1108694023.geojson
+++ b/data/110/869/402/3/1108694023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.411364,
-    "geom:area_square_m":4911726766.193972,
+    "geom:area_square_m":4911727316.399093,
     "geom:bbox":"-73.293977,-15.572365,-72.301934,-14.644061",
     "geom:latitude":-15.065511,
     "geom:longitude":-72.804108,
@@ -138,9 +138,10 @@
         "hasc:id":"PE.AR.LU",
         "wd:id":"Q1779698"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415410,
-    "wof:geomhash":"594c69dc43bb34f3a4bef3a9a7f8dbff",
+    "wof:geomhash":"fc71e97c7a5d51142bb3a2c9c3440b29",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108694023,
-    "wof:lastmodified":1690850413,
+    "wof:lastmodified":1695886600,
     "wof:name":"La Uni\u00f3n",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/110/869/402/7/1108694027.geojson
+++ b/data/110/869/402/7/1108694027.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.576913,
-    "geom:area_square_m":6870765386.47348,
+    "geom:area_square_m":6870765756.103325,
     "geom:bbox":"-73.261535,-16.461076,-71.893891,-14.632807",
     "geom:latitude":-15.598116,
     "geom:longitude":-72.731342,
@@ -135,9 +135,10 @@
         "hasc:id":"PE.AR.CS",
         "wd:id":"Q1814253"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415420,
-    "wof:geomhash":"bbb34c215950d8b26f45ed55ee761885",
+    "wof:geomhash":"2961cfa11e0ac3bf2b4a87f62d87398a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108694027,
-    "wof:lastmodified":1690850413,
+    "wof:lastmodified":1695886600,
     "wof:name":"Condesuyos",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/110/869/402/9/1108694029.geojson
+++ b/data/110/869/402/9/1108694029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.23173,
-    "geom:area_square_m":2731563864.101895,
+    "geom:area_square_m":2731563504.509092,
     "geom:bbox":"-71.139086,-17.976615,-70.344131,-17.195268",
     "geom:latitude":-17.579178,
     "geom:longitude":-70.731113,
@@ -138,9 +138,10 @@
         "hasc:id":"PE.TA.JB",
         "wd:id":"Q589047"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415423,
-    "wof:geomhash":"04fdec4debb93c4c01f394e655818fef",
+    "wof:geomhash":"7ec812f0f052f465e276b398f694930f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1108694029,
-    "wof:lastmodified":1690850413,
+    "wof:lastmodified":1695886601,
     "wof:name":"Jorge Basadre",
     "wof:parent_id":85675861,
     "wof:placetype":"county",

--- a/data/110/869/403/1/1108694031.geojson
+++ b/data/110/869/403/1/1108694031.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195657,
-    "geom:area_square_m":2312200047.191811,
+    "geom:area_square_m":2312200289.791427,
     "geom:bbox":"-70.570412,-17.46074,-70.070686,-16.77041",
     "geom:latitude":-17.114197,
     "geom:longitude":-70.302336,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"PE.TA.CD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415425,
-    "wof:geomhash":"2cb3e33559eaf78817bd006a6a083474",
+    "wof:geomhash":"8643d8097f8f878bd6a70d223e884e66",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108694031,
-    "wof:lastmodified":1627522493,
+    "wof:lastmodified":1695886130,
     "wof:name":"Candarave",
     "wof:parent_id":85675861,
     "wof:placetype":"county",

--- a/data/110/869/403/3/1108694033.geojson
+++ b/data/110/869/403/3/1108694033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.234786,
-    "geom:area_square_m":2770105060.86269,
+    "geom:area_square_m":2770105283.642543,
     "geom:bbox":"-70.345787,-17.778303,-69.468533,-17.035559",
     "geom:latitude":-17.413945,
     "geom:longitude":-69.971584,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"PE.TA.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415427,
-    "wof:geomhash":"67b20a47856b781ee560826530feb734",
+    "wof:geomhash":"80e8d722feda8cc11fa28f67f42b5f1b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108694033,
-    "wof:lastmodified":1627522498,
+    "wof:lastmodified":1695886138,
     "wof:name":"Tarata",
     "wof:parent_id":85675861,
     "wof:placetype":"county",

--- a/data/110/869/403/5/1108694035.geojson
+++ b/data/110/869/403/5/1108694035.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.186422,
-    "geom:area_square_m":2256705044.432604,
+    "geom:area_square_m":2256705044.433107,
     "geom:bbox":"-75.6943046875,-12.1939726562,-74.7191933594,-11.4270488281",
     "geom:latitude":-11.765539,
     "geom:longitude":-75.129926,
@@ -188,9 +188,10 @@
     "wof:concordances":{
         "hasc:id":"PE.JU.CN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415434,
-    "wof:geomhash":"6da40e418ca0cad71f359054d85a36a3",
+    "wof:geomhash":"bc05a45b1687ecbfc14fd11e551add39",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":1108694035,
-    "wof:lastmodified":1566675948,
+    "wof:lastmodified":1695886601,
     "wof:name":"Concepci\u00f3n",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/110/869/403/7/1108694037.geojson
+++ b/data/110/869/403/7/1108694037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.310622,
-    "geom:area_square_m":3755617310.528525,
+    "geom:area_square_m":3755617697.602808,
     "geom:bbox":"-75.582932,-12.683607,-74.486695,-11.657311",
     "geom:latitude":-12.093988,
     "geom:longitude":-75.065022,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.JU.HO",
         "wd:id":"Q1777621"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415436,
-    "wof:geomhash":"317e10cec3f4670d22d2051e2ee51a59",
+    "wof:geomhash":"34de64b2ba758d76a961bf9d0cf47c9a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108694037,
-    "wof:lastmodified":1690850414,
+    "wof:lastmodified":1695886601,
     "wof:name":"Huancayo",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/110/869/403/9/1108694039.geojson
+++ b/data/110/869/403/9/1108694039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.169566,
-    "geom:area_square_m":2079453017.750448,
+    "geom:area_square_m":2079453213.244814,
     "geom:bbox":"-79.367812,-7.660812,-78.60907,-7.178822",
     "geom:latitude":-7.356124,
     "geom:longitude":-78.979469,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.CJ.CO",
         "wd:id":"Q1948003"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415442,
-    "wof:geomhash":"292657b9c584c1fccc526cd301e58727",
+    "wof:geomhash":"07442cee7d5d3c3b540bf7fd85c42893",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108694039,
-    "wof:lastmodified":1690850414,
+    "wof:lastmodified":1695886601,
     "wof:name":"Contumaz\u00e1",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/404/1/1108694041.geojson
+++ b/data/110/869/404/1/1108694041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.167145,
-    "geom:area_square_m":14315515268.233778,
+    "geom:area_square_m":14315515476.488876,
     "geom:bbox":"-77.765205,-8.064725,-76.551643,-6.381514",
     "geom:latitude":-7.273809,
     "geom:longitude":-77.182611,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.SM.MC",
         "wd:id":"Q1947944"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415443,
-    "wof:geomhash":"59441d62800f3b1e06e569dfe11a107a",
+    "wof:geomhash":"bdaf869e2290297c0e00606f86cef838",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108694041,
-    "wof:lastmodified":1690850415,
+    "wof:lastmodified":1695886602,
     "wof:name":"Mariscal C\u00e1ceres",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/404/5/1108694045.geojson
+++ b/data/110/869/404/5/1108694045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146246,
-    "geom:area_square_m":1792718964.990481,
+    "geom:area_square_m":1792719109.980517,
     "geom:bbox":"-78.383281,-7.762836,-77.741707,-7.343857",
     "geom:latitude":-7.540054,
     "geom:longitude":-78.099229,
@@ -141,9 +141,10 @@
         "hasc:id":"PE.CJ.CJ",
         "wd:id":"Q751373"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415445,
-    "wof:geomhash":"6598efcb8118889425c077aaaada9c1a",
+    "wof:geomhash":"736a191bc98ad148a180df21094fa17a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":1108694045,
-    "wof:lastmodified":1690850415,
+    "wof:lastmodified":1695886746,
     "wof:name":"Cajabamba",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/110/869/404/7/1108694047.geojson
+++ b/data/110/869/404/7/1108694047.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231079,
-    "geom:area_square_m":2843286511.883935,
+    "geom:area_square_m":2843286613.166806,
     "geom:bbox":"-78.135033,-6.13024,-77.651963,-5.133043",
     "geom:latitude":-5.683797,
     "geom:longitude":-77.873104,
@@ -132,9 +132,10 @@
         "hasc:id":"PE.AM.BN",
         "wd:id":"Q1342814"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415446,
-    "wof:geomhash":"88f33d79d48e16528e7c07165be1bf76",
+    "wof:geomhash":"d66fd4276ae8c6cc325e2996f385774b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108694047,
-    "wof:lastmodified":1690850415,
+    "wof:lastmodified":1695886602,
     "wof:name":"Bongar\u00e1",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/404/9/1108694049.geojson
+++ b/data/110/869/404/9/1108694049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.445847,
-    "geom:area_square_m":17830196911.047329,
+    "geom:area_square_m":17830196102.692444,
     "geom:bbox":"-78.652535,-5.413854,-77.537499,-2.987278",
     "geom:latitude":-4.165664,
     "geom:longitude":-78.035827,
@@ -135,9 +135,10 @@
         "hasc:id":"PE.AM.CQ",
         "wd:id":"Q1288434"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415449,
-    "wof:geomhash":"64753a33190c12fa02d909f321a910ea",
+    "wof:geomhash":"e47f214f49928bbb3b7795ce7dd247db",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1108694049,
-    "wof:lastmodified":1690850414,
+    "wof:lastmodified":1695886601,
     "wof:name":"Condorcanqui",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/405/1/1108694051.geojson
+++ b/data/110/869/405/1/1108694051.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.846851,
-    "geom:area_square_m":47438696839.694489,
+    "geom:area_square_m":47438696945.97406,
     "geom:bbox":"-77.825742,-5.746232,-75.746805,-2.512339",
     "geom:latitude":-4.130357,
     "geom:longitude":-76.985832,
@@ -129,9 +129,10 @@
         "hasc:id":"PE.LO.AA",
         "wd:id":"Q1920572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415453,
-    "wof:geomhash":"9c66fd58ecf76b2111de56fc3b444725",
+    "wof:geomhash":"5532bccc835752a19e4bc4e4cf65e9f4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1108694051,
-    "wof:lastmodified":1690850412,
+    "wof:lastmodified":1695886600,
     "wof:name":"Datem Del Mara\u00f1\u00f3n",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/110/869/405/3/1108694053.geojson
+++ b/data/110/869/405/3/1108694053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318007,
-    "geom:area_square_m":3911333314.241258,
+    "geom:area_square_m":3911333282.103819,
     "geom:bbox":"-77.746643,-6.41393,-76.745201,-5.406285",
     "geom:latitude":-5.902243,
     "geom:longitude":-77.122317,
@@ -140,9 +140,10 @@
     "wof:concordances":{
         "hasc:id":"PE.SM.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415454,
-    "wof:geomhash":"dd6450e3b2f098b5d4bc9015f0f5f09b",
+    "wof:geomhash":"7880f2f9adf731038f41d7019134f171",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108694053,
-    "wof:lastmodified":1636500223,
+    "wof:lastmodified":1695886746,
     "wof:name":"Moyobamba",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/869/405/5/1108694055.geojson
+++ b/data/110/869/405/5/1108694055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.119818,
-    "geom:area_square_m":50659848487.71624,
+    "geom:area_square_m":50659847585.452675,
     "geom:bbox":"-75.569549,-7.534526,-72.855127,-4.44623",
     "geom:latitude":-5.999285,
     "geom:longitude":-74.048753,
@@ -147,9 +147,10 @@
         "hasc:id":"PE.LO.RQ",
         "wd:id":"Q1944325"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415456,
-    "wof:geomhash":"4f7d7115fcc294696e71fea8fe8c8eed",
+    "wof:geomhash":"b0a3170ef497ac2a03f148673046cec9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -159,7 +160,7 @@
         }
     ],
     "wof:id":1108694055,
-    "wof:lastmodified":1690850412,
+    "wof:lastmodified":1695886747,
     "wof:name":"Requena",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/110/869/405/7/1108694057.geojson
+++ b/data/110/869/405/7/1108694057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.379006,
-    "geom:area_square_m":4658384372.489836,
+    "geom:area_square_m":4658384466.498883,
     "geom:bbox":"-76.883812,-6.693941,-75.900406,-5.951768",
     "geom:latitude":-6.275692,
     "geom:longitude":-76.417985,
@@ -113,9 +113,10 @@
     "wof:concordances":{
         "hasc:id":"PE.SM.LS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1474415459,
-    "wof:geomhash":"8af73991aba7320265a06ee8b3246d33",
+    "wof:geomhash":"f8626a49e0c32a2d777bb4d56f7a603f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108694057,
-    "wof:lastmodified":1636500222,
+    "wof:lastmodified":1695886746,
     "wof:name":"Lamas",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/110/880/561/7/1108805617.geojson
+++ b/data/110/880/561/7/1108805617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.667802,
-    "geom:area_square_m":67706641224.006874,
+    "geom:area_square_m":67706641485.968994,
     "geom:bbox":"-71.118172,-17.295395,-68.826675,-13.003803",
     "geom:latitude":-14.926866,
     "geom:longitude":-69.953208,
@@ -238,12 +238,14 @@
     "wof:concordances":{
         "fips:code":"PE21",
         "hasc:id":"PE.PU",
+        "iso:code":"PE-PUN",
         "iso:id":"PE-PUN",
         "wd:id":"Q205104"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:created":1485547419,
-    "wof:geomhash":"69a21f9cd278bf73f14dc81002527cee",
+    "wof:geomhash":"9aca9fb0c306f8d78a7785b3fdc9f52b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -260,7 +262,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850404,
+    "wof:lastmodified":1695884864,
     "wof:name":"Puno",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/117/561/312/1/1175613121.geojson
+++ b/data/117/561/312/1/1175613121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.953232,
-    "geom:area_square_m":35744876975.944099,
+    "geom:area_square_m":35744875642.318161,
     "geom:bbox":"-77.890601,-13.323489,-75.467197,-10.27009",
     "geom:latitude":-11.781286,
     "geom:longitude":-76.626647,
@@ -374,13 +374,15 @@
         "gn:id":3936452,
         "gp:id":2346482,
         "hasc:id":"PE.LR",
+        "iso:code":"PE-LIM",
         "iso:id":"PE-LIM",
         "qs_pg:id":219592,
         "wd:id":"Q211795",
         "wk:page":"Lima Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
-    "wof:geomhash":"6a1c207994b8597488d7131691f3cadb",
+    "wof:geomhash":"86bfabc6f614206b0f39d31a8551cea8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -397,7 +399,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850417,
+    "wof:lastmodified":1695884865,
     "wof:name":"Lima",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/421/167/831/421167831.geojson
+++ b/data/421/167/831/421167831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191718,
-    "geom:area_square_m":2282122550.684854,
+    "geom:area_square_m":2282122175.53495,
     "geom:bbox":"-70.896561,-16.034252,-69.961937,-15.313426",
     "geom:latitude":-15.704292,
     "geom:longitude":-70.425414,
@@ -153,12 +153,13 @@
         "qs_pg:id":424725,
         "wd:id":"Q1944337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008745,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"2d4996dcd57ee6a06bad940ea7b64b3f",
+    "wof:geomhash":"116b422ab6e1f054f287e45a30c2a445",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421167831,
-    "wof:lastmodified":1690850431,
+    "wof:lastmodified":1695886746,
     "wof:name":"San Rom\u00e1n",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/170/339/421170339.geojson
+++ b/data/421/170/339/421170339.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.337551,
-    "geom:area_square_m":4052875707.59658,
+    "geom:area_square_m":4052876112.837743,
     "geom:bbox":"-73.748352,-14.544309,-72.944152,-13.41158",
     "geom:latitude":-13.828168,
     "geom:longitude":-73.392918,
@@ -149,12 +149,13 @@
         "wd:id":"Q1798747",
         "wk:page":"Andahuaylas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008849,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40d4f8d3f0880f4656c9d5201d3b876b",
+    "wof:geomhash":"afbadf9b877c3727c87c34e4908acf07",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421170339,
-    "wof:lastmodified":1690850471,
+    "wof:lastmodified":1695886752,
     "wof:name":"Andahuaylas",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/170/341/421170341.geojson
+++ b/data/421/170/341/421170341.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.525149,
-    "geom:area_square_m":6459460316.612313,
+    "geom:area_square_m":6459459374.798621,
     "geom:bbox":"-81.149557,-6.371807,-80.052939,-5.310076",
     "geom:latitude":-5.870557,
     "geom:longitude":-80.671605,
@@ -184,12 +184,13 @@
         "qs_pg:id":483636,
         "wd:id":"Q3236446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008849,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c260a0768bda16b553cbeb09a7242df",
+    "wof:geomhash":"0772202b18bd247b73d04194f9fed6aa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -199,7 +200,7 @@
         }
     ],
     "wof:id":421170341,
-    "wof:lastmodified":1690850473,
+    "wof:lastmodified":1695886751,
     "wof:name":"Sechura",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/170/655/421170655.geojson
+++ b/data/421/170/655/421170655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.288912,
-    "geom:area_square_m":3470310197.87659,
+    "geom:area_square_m":3470309956.586773,
     "geom:bbox":"-73.171959,-14.170846,-72.399109,-13.38301",
     "geom:latitude":-13.733222,
     "geom:longitude":-72.834363,
@@ -158,12 +158,13 @@
         "wd:id":"Q1771870",
         "wk:page":"Abancay Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008862,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7aae3c2934833ee45f3edcd508b5aa9",
+    "wof:geomhash":"554c55c1eaec5efee67a95633a245c73",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421170655,
-    "wof:lastmodified":1690850474,
+    "wof:lastmodified":1695886752,
     "wof:name":"Abancay",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/170/661/421170661.geojson
+++ b/data/421/170/661/421170661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.187792,
-    "geom:area_square_m":2293838092.289009,
+    "geom:area_square_m":2293837754.578539,
     "geom:bbox":"-78.07315,-9.261451,-77.574463,-8.655328",
     "geom:latitude":-8.943659,
     "geom:longitude":-77.828432,
@@ -155,12 +155,13 @@
         "wd:id":"Q1779670",
         "wk:page":"Huaylas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008862,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28efea64c27943b39f303f89d9a8d923",
+    "wof:geomhash":"78a86536698e0d3171d29aa702bc269a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421170661,
-    "wof:lastmodified":1690850473,
+    "wof:lastmodified":1695886753,
     "wof:name":"Huaylas",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/170/663/421170663.geojson
+++ b/data/421/170/663/421170663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264714,
-    "geom:area_square_m":3253359561.36324,
+    "geom:area_square_m":3253359600.245744,
     "geom:bbox":"-78.419961,-6.74582,-77.802498,-5.902344",
     "geom:latitude":-6.314812,
     "geom:longitude":-78.083136,
@@ -158,12 +158,13 @@
         "wd:id":"Q268277",
         "wk:page":"Luya Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008862,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8d9bea3fb05b0e7996589dc6be4aab03",
+    "wof:geomhash":"9075c0a6f1ae365b9f04e736a161734a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421170663,
-    "wof:lastmodified":1690850475,
+    "wof:lastmodified":1695886753,
     "wof:name":"Luya",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/421/170/665/421170665.geojson
+++ b/data/421/170/665/421170665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.386816,
-    "geom:area_square_m":28837311643.910709,
+    "geom:area_square_m":28837311601.690384,
     "geom:bbox":"-72.428848,-13.273475,-70.038201,-11.315869",
     "geom:latitude":-12.279946,
     "geom:longitude":-71.285274,
@@ -152,12 +152,13 @@
         "wd:id":"Q2320717",
         "wk:page":"Man\u00fa Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008862,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"62ca91f858fcc2dea343a89ec20809a9",
+    "wof:geomhash":"04493b995da83442df96b44adb4f6f9e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421170665,
-    "wof:lastmodified":1690850475,
+    "wof:lastmodified":1695886753,
     "wof:name":"Manu",
     "wof:parent_id":85675847,
     "wof:placetype":"county",

--- a/data/421/170/671/421170671.geojson
+++ b/data/421/170/671/421170671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.494903,
-    "geom:area_square_m":6056212745.508554,
+    "geom:area_square_m":6056212319.243067,
     "geom:bbox":"-77.143111,-8.795639,-76.107559,-7.686061",
     "geom:latitude":-8.249278,
     "geom:longitude":-76.635011,
@@ -159,12 +159,13 @@
         "hasc:id":"PE.SM.TO",
         "qs_pg:id":1195320
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008862,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b5fae584ae8fd1ed96f3f8760e63f2a2",
+    "wof:geomhash":"0b6add2915c8b5f2d96404c0f5970a46",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421170671,
-    "wof:lastmodified":1636500285,
+    "wof:lastmodified":1695886752,
     "wof:name":"Tocache",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/421/170/673/421170673.geojson
+++ b/data/421/170/673/421170673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.279932,
-    "geom:area_square_m":3382686875.110578,
+    "geom:area_square_m":3382686683.374109,
     "geom:bbox":"-75.139687,-12.534428,-74.343482,-11.984594",
     "geom:latitude":-12.242928,
     "geom:longitude":-74.769131,
@@ -152,12 +152,13 @@
         "wd:id":"Q1948195",
         "wk:page":"Tayacaja Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008863,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01cde2d2c4093203a67697c1f917d461",
+    "wof:geomhash":"5f32fbc70755f366762b0a3c4cf01cc4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421170673,
-    "wof:lastmodified":1690850472,
+    "wof:lastmodified":1695886753,
     "wof:name":"Tayacaja",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/170/675/421170675.geojson
+++ b/data/421/170/675/421170675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22074,
-    "geom:area_square_m":2676752778.400311,
+    "geom:area_square_m":2676752001.503114,
     "geom:bbox":"-75.97184,-11.600689,-75.402115,-10.899879",
     "geom:latitude":-11.2806,
     "geom:longitude":-75.680254,
@@ -197,12 +197,13 @@
         "wd:id":"Q946269",
         "wk:page":"Tarma Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008863,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"02c7471b451ca441ec58ab40a734c7f5",
+    "wof:geomhash":"8077b996732ee09972cbabe0e4f14d6c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -212,7 +213,7 @@
         }
     ],
     "wof:id":421170675,
-    "wof:lastmodified":1690850471,
+    "wof:lastmodified":1695886751,
     "wof:name":"Tarma",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/170/677/421170677.geojson
+++ b/data/421/170/677/421170677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145659,
-    "geom:area_square_m":1783297603.278343,
+    "geom:area_square_m":1783297434.637928,
     "geom:bbox":"-79.210394,-8.371688,-78.637924,-7.795686",
     "geom:latitude":-8.063381,
     "geom:longitude":-78.897158,
@@ -362,12 +362,13 @@
         "qs_pg:id":1195328,
         "wd:id":"Q2527815"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008863,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0428c406ba30be1155af86a23054b722",
+    "wof:geomhash":"399cfc855af0f0fd1341ea9b24fa757c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -377,7 +378,7 @@
         }
     ],
     "wof:id":421170677,
-    "wof:lastmodified":1690850474,
+    "wof:lastmodified":1695886752,
     "wof:name":"Trujillo",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/171/561/421171561.geojson
+++ b/data/421/171/561/421171561.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.423709,
-    "geom:area_square_m":5221484987.060744,
+    "geom:area_square_m":5221485163.517741,
     "geom:bbox":"-80.293453,-5.111062,-79.388503,-4.285578",
     "geom:latitude":-4.714318,
     "geom:longitude":-79.813518,
@@ -137,12 +137,13 @@
         "wd:id":"Q1367672",
         "wk:page":"Ayabaca Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008898,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b7d935f0351f5ca5b8943089e1075a4f",
+    "wof:geomhash":"95f1a8388befd4e19efe80427c0264ba",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421171561,
-    "wof:lastmodified":1690850484,
+    "wof:lastmodified":1695886756,
     "wof:name":"Ayabaca",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/171/957/421171957.geojson
+++ b/data/421/171/957/421171957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.172085,
-    "geom:area_square_m":38772291923.188293,
+    "geom:area_square_m":38772291727.505928,
     "geom:bbox":"-75.449098,-10.093854,-72.939448,-7.294762",
     "geom:latitude":-8.676551,
     "geom:longitude":-74.061849,
@@ -161,12 +161,13 @@
         "qs_pg:id":1288005,
         "wd:id":"Q579906"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008913,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"25795c6ca296a2f05663ab081d14560e",
+    "wof:geomhash":"ca28978ccad9ac5e2a47e4089a168ff4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421171957,
-    "wof:lastmodified":1690850484,
+    "wof:lastmodified":1695886756,
     "wof:name":"Coronel Portillo",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/421/171/959/421171959.geojson
+++ b/data/421/171/959/421171959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.484548,
-    "geom:area_square_m":5745964695.333641,
+    "geom:area_square_m":5745964752.590304,
     "geom:bbox":"-71.466264,-16.979844,-70.30584,-15.974455",
     "geom:latitude":-16.458818,
     "geom:longitude":-70.831346,
@@ -158,12 +158,13 @@
         "qs_pg:id":1288007,
         "wd:id":"Q1947893"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008913,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6b31a1c992fcecd7cf401029acc95f1",
+    "wof:geomhash":"3b3c472fd9541009a6625dcac4262c97",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421171959,
-    "wof:lastmodified":1690850485,
+    "wof:lastmodified":1695886756,
     "wof:name":"Gral. S\u00e1nchez Cerro",
     "wof:parent_id":85675857,
     "wof:placetype":"county",

--- a/data/421/171/961/421171961.geojson
+++ b/data/421/171/961/421171961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.697787,
-    "geom:area_square_m":8210896818.008162,
+    "geom:area_square_m":8210896818.009192,
     "geom:bbox":"-70.8900919612,-18.3509285287,-69.4681565042,-17.3941347656",
     "geom:latitude":-17.892395,
     "geom:longitude":-70.222877,
@@ -210,12 +210,13 @@
         "hasc:id":"PE.TA.TC",
         "qs_pg:id":1288024
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008914,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6d39a76c894ae9e625b83b7da7426017",
+    "wof:geomhash":"204da912a43fc7f722e5822454ffc706",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -225,7 +226,7 @@
         }
     ],
     "wof:id":421171961,
-    "wof:lastmodified":1582343553,
+    "wof:lastmodified":1695886757,
     "wof:name":"Tacna",
     "wof:parent_id":85675861,
     "wof:placetype":"county",

--- a/data/421/171/963/421171963.geojson
+++ b/data/421/171/963/421171963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086538,
-    "geom:area_square_m":1031955486.821655,
+    "geom:area_square_m":1031955793.708292,
     "geom:bbox":"-69.669199,-15.537979,-69.172639,-15.162787",
     "geom:latitude":-15.335348,
     "geom:longitude":-69.379982,
@@ -129,12 +129,13 @@
         "hasc:id":"PE.PU.MH",
         "qs_pg:id":1288025
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008914,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a445a25cfadb250b722f35594aeb344e",
+    "wof:geomhash":"44bd33c0f3a323ed9e018815d1b6748f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421171963,
-    "wof:lastmodified":1627522495,
+    "wof:lastmodified":1695886131,
     "wof:name":"Moho",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/171/973/421171973.geojson
+++ b/data/421/171/973/421171973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060215,
-    "geom:area_square_m":735664283.344546,
+    "geom:area_square_m":735664225.833102,
     "geom:bbox":"-77.56208,-9.006863,-77.16076,-8.703049",
     "geom:latitude":-8.870217,
     "geom:longitude":-77.340456,
@@ -181,12 +181,13 @@
         "qs_pg:id":1288732,
         "wd:id":"Q1779663"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008914,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4af11ee6b02af7add0d16bb04034a327",
+    "wof:geomhash":"bf62652b1eb9ca90e370fdb154534ba4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -196,7 +197,7 @@
         }
     ],
     "wof:id":421171973,
-    "wof:lastmodified":1690850485,
+    "wof:lastmodified":1695886757,
     "wof:name":"Mariscal Luzuriaga",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/172/423/421172423.geojson
+++ b/data/421/172/423/421172423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243288,
-    "geom:area_square_m":2984589109.842362,
+    "geom:area_square_m":2984588520.889509,
     "geom:bbox":"-78.746551,-7.556424,-78.184937,-6.79941",
     "geom:latitude":-7.197702,
     "geom:longitude":-78.469531,
@@ -152,12 +152,13 @@
         "wd:id":"Q1431135",
         "wk:page":"Cajamarca Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008940,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7cf38c4d2f76bd3b3bc80a776f882a4b",
+    "wof:geomhash":"3d63ede69010a279e9c930c4de31501c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421172423,
-    "wof:lastmodified":1690850449,
+    "wof:lastmodified":1695886749,
     "wof:name":"Cajamarca",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/172/425/421172425.geojson
+++ b/data/421/172/425/421172425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044215,
-    "geom:area_square_m":531504943.737077,
+    "geom:area_square_m":531504746.473655,
     "geom:bbox":"-72.168586,-13.649062,-71.804627,-13.429496",
     "geom:latitude":-13.551424,
     "geom:longitude":-71.981656,
@@ -161,12 +161,13 @@
         "wd:id":"Q1132101",
         "wk:page":"Cusco Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008940,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e70b214036f750b060f6a511ab5390b3",
+    "wof:geomhash":"5bd95c76edd01336fc96c8c98cb3c550",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421172425,
-    "wof:lastmodified":1690850448,
+    "wof:lastmodified":1695886749,
     "wof:name":"Cusco",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/172/463/421172463.geojson
+++ b/data/421/172/463/421172463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.327936,
-    "geom:area_square_m":4014090460.812344,
+    "geom:area_square_m":4014090454.751496,
     "geom:bbox":"-77.701676,-8.533326,-76.90184,-7.593502",
     "geom:latitude":-8.142388,
     "geom:longitude":-77.323824,
@@ -155,12 +155,13 @@
         "wd:id":"Q1948180",
         "wk:page":"Pataz Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008943,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e5298e9e4c18d593b9c8983b6e1272f",
+    "wof:geomhash":"c9b31513c8123137d13eb3ed97dfa669",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421172463,
-    "wof:lastmodified":1690850449,
+    "wof:lastmodified":1695886750,
     "wof:name":"Pataz",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/172/895/421172895.geojson
+++ b/data/421/172/895/421172895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.326805,
-    "geom:area_square_m":4020514685.504601,
+    "geom:area_square_m":4020514297.166745,
     "geom:bbox":"-78.709168,-6.18865,-77.930352,-5.343592",
     "geom:latitude":-5.769329,
     "geom:longitude":-78.329042,
@@ -173,12 +173,13 @@
         "wd:id":"Q941183",
         "wk:page":"Utcubamba Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459008958,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ae579967d7cf9f5bc4048715a808936c",
+    "wof:geomhash":"161db171c99381d69322a084e323b550",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":421172895,
-    "wof:lastmodified":1690850449,
+    "wof:lastmodified":1695886750,
     "wof:name":"Utcubamba",
     "wof:parent_id":85675895,
     "wof:placetype":"county",

--- a/data/421/175/155/421175155.geojson
+++ b/data/421/175/155/421175155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.22363,
-    "geom:area_square_m":39205691393.564438,
+    "geom:area_square_m":39205692336.124146,
     "geom:bbox":"-74.573014,-11.448199,-72.12017,-9.411747",
     "geom:latitude":-10.389865,
     "geom:longitude":-73.21982,
@@ -166,12 +166,13 @@
         "qs_pg:id":355636,
         "wd:id":"Q1920509"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009057,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9747373ddcc63486c47f39aa250a47a0",
+    "wof:geomhash":"308b92715cb3bc2551e948c4573ef9ca",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421175155,
-    "wof:lastmodified":1690850460,
+    "wof:lastmodified":1695886751,
     "wof:name":"Atalaya",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/421/175/157/421175157.geojson
+++ b/data/421/175/157/421175157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293998,
-    "geom:area_square_m":3542360677.034436,
+    "geom:area_square_m":3542360184.976211,
     "geom:bbox":"-72.369941,-13.575111,-71.71875,-12.506617",
     "geom:latitude":-12.984528,
     "geom:longitude":-72.03876,
@@ -140,12 +140,13 @@
         "wd:id":"Q1948019",
         "wk:page":"Calca Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009057,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e41224dcab5b5a0c7f8e35fc3e8550e7",
+    "wof:geomhash":"a44d97630a1934ce7a98708f6405aca3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421175157,
-    "wof:lastmodified":1690850458,
+    "wof:lastmodified":1695886750,
     "wof:name":"Calca",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/175/159/421175159.geojson
+++ b/data/421/175/159/421175159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.338469,
-    "geom:area_square_m":4014865673.690747,
+    "geom:area_square_m":4014865673.690343,
     "geom:bbox":"-73.2915892459,-16.9270188904,-72.1277382812,-15.8763417969",
     "geom:latitude":-16.403134,
     "geom:longitude":-72.804252,
@@ -132,12 +132,13 @@
         "hasc:id":"PE.AR.CM",
         "qs_pg:id":355654
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009057,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8205edc5a69cd15648f219469132f55d",
+    "wof:geomhash":"8396b1e867b84843b8ce715ebe10e506",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":421175159,
-    "wof:lastmodified":1582343541,
+    "wof:lastmodified":1695886750,
     "wof:name":"Caman\u00e1",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/175/161/421175161.geojson
+++ b/data/421/175/161/421175161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.345901,
-    "geom:area_square_m":4143803164.055354,
+    "geom:area_square_m":4143803020.738182,
     "geom:bbox":"-73.577064,-14.84283,-72.978943,-13.799859",
     "geom:latitude":-14.341193,
     "geom:longitude":-73.247678,
@@ -158,12 +158,13 @@
         "wd:id":"Q1814234",
         "wk:page":"Aymaraes Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009057,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"debab54fb3b1a874850086636369149b",
+    "wof:geomhash":"613b614030e3d50d1b03a05fa4970baf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421175161,
-    "wof:lastmodified":1690850458,
+    "wof:lastmodified":1695886751,
     "wof:name":"Aymaraes",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/175/163/421175163.geojson
+++ b/data/421/175/163/421175163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173118,
-    "geom:area_square_m":2135500351.641608,
+    "geom:area_square_m":2135500446.492179,
     "geom:bbox":"-81.041155,-4.215451,-80.515182,-3.637441",
     "geom:latitude":-3.96978,
     "geom:longitude":-80.740812,
@@ -164,12 +164,13 @@
         "qs_pg:id":355686,
         "wd:id":"Q1422590"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009057,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d435391ab45c0b1a8a27b29eac725ad",
+    "wof:geomhash":"77f7bfc03c344c2b7ffb920cd6405c50",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421175163,
-    "wof:lastmodified":1690850459,
+    "wof:lastmodified":1695886751,
     "wof:name":"Contralmirante Villar",
     "wof:parent_id":85675831,
     "wof:placetype":"county",

--- a/data/421/175/167/421175167.geojson
+++ b/data/421/175/167/421175167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.349056,
-    "geom:area_square_m":4210216301.51231,
+    "geom:area_square_m":4210216326.653068,
     "geom:bbox":"-75.579734,-13.185861,-74.68451,-12.360742",
     "geom:latitude":-12.718756,
     "geom:longitude":-75.087145,
@@ -176,12 +176,13 @@
         "wd:id":"Q2088859",
         "wk:page":"Huancavelica Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009057,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ad836b66e71e6cc590f167b7afa1774b",
+    "wof:geomhash":"50ee1a3f2b12a5f2d8ff6afc46b988a3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -191,7 +192,7 @@
         }
     ],
     "wof:id":421175167,
-    "wof:lastmodified":1690850458,
+    "wof:lastmodified":1695886750,
     "wof:name":"Huancavelica",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/175/173/421175173.geojson
+++ b/data/421/175/173/421175173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.575966,
-    "geom:area_square_m":68783350116.289886,
+    "geom:area_square_m":68783353091.061615,
     "geom:bbox":"-76.535454,-5.739953,-73.378715,-1.794015",
     "geom:latitude":-3.849129,
     "geom:longitude":-75.230277,
@@ -164,12 +164,13 @@
         "wd:id":"Q1995145",
         "wk:page":"Loreto Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009058,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5f53ad6d56fd824a225e15eb72976bb4",
+    "wof:geomhash":"e0fe26506a77fe5025c671e83d13db0d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421175173,
-    "wof:lastmodified":1690850459,
+    "wof:lastmodified":1695886750,
     "wof:name":"Loreto",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/175/175/421175175.geojson
+++ b/data/421/175/175/421175175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.472161,
-    "geom:area_square_m":17910274014.111809,
+    "geom:area_square_m":17910273774.205685,
     "geom:bbox":"-75.986207,-10.912568,-74.131943,-9.428311",
     "geom:latitude":-10.294292,
     "geom:longitude":-74.97368,
@@ -137,12 +137,13 @@
         "wd:id":"Q960169",
         "wk:page":"Oxapampa Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009058,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3ae8263db6ebdc4d77541ba2d48a640f",
+    "wof:geomhash":"60464b291866013c9ee8d1676d04a784",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421175175,
-    "wof:lastmodified":1690850459,
+    "wof:lastmodified":1695886751,
     "wof:name":"Oxapampa",
     "wof:parent_id":85675883,
     "wof:placetype":"county",

--- a/data/421/175/177/421175177.geojson
+++ b/data/421/175/177/421175177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.451437,
-    "geom:area_square_m":5546166387.00915,
+    "geom:area_square_m":5546165869.665648,
     "geom:bbox":"-76.491562,-6.871258,-75.486701,-6.000217",
     "geom:latitude":-6.501998,
     "geom:longitude":-75.872,
@@ -161,12 +161,13 @@
         "wd:id":"Q588491",
         "wk:page":"San Mart\u00edn Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009058,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"286d02c9ce2e070f9d7b3d689688412c",
+    "wof:geomhash":"f6af7b155e1119a82c9a4dce31471f88",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -176,7 +177,7 @@
         }
     ],
     "wof:id":421175177,
-    "wof:lastmodified":1690850460,
+    "wof:lastmodified":1695886752,
     "wof:name":"San Mart\u00edn",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/421/175/219/421175219.geojson
+++ b/data/421/175/219/421175219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.086392,
-    "geom:area_square_m":38072553858.62262,
+    "geom:area_square_m":38072551431.149155,
     "geom:bbox":"-73.236541,-5.146143,-69.948846,-2.785238",
     "geom:latitude":-3.926565,
     "geom:longitude":-71.700147,
@@ -116,12 +116,13 @@
         "hasc:id":"PE.LO.MR",
         "qs_pg:id":361242
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009060,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6400fbc14fc3e65c54033c8c7c0ad038",
+    "wof:geomhash":"7130df9b6a2b07a58efa0c8fd679847d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421175219,
-    "wof:lastmodified":1627522495,
+    "wof:lastmodified":1695886132,
     "wof:name":"Mariscal Ram\u00f3n Castilla",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/175/433/421175433.geojson
+++ b/data/421/175/433/421175433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043181,
-    "geom:area_square_m":527090706.610999,
+    "geom:area_square_m":527090706.611371,
     "geom:bbox":"-77.5325703125,-9.32448828125,-77.2628105469,-9.05648828125",
     "geom:latitude":-9.189951,
     "geom:longitude":-77.39885,
@@ -479,12 +479,13 @@
         "hasc:id":"PE.AN.AI",
         "qs_pg:id":962610
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009067,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"828649c4a9a1053b1be21742db234806",
+    "wof:geomhash":"924f295446f26f783d771d28a3870d55",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -494,7 +495,7 @@
         }
     ],
     "wof:id":421175433,
-    "wof:lastmodified":1582343544,
+    "wof:lastmodified":1695886752,
     "wof:name":"Asunci\u00f3n",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/176/081/421176081.geojson
+++ b/data/421/176/081/421176081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.121422,
-    "geom:area_square_m":1480127847.513209,
+    "geom:area_square_m":1480127930.648411,
     "geom:bbox":"-76.948051,-10.00991,-76.200287,-9.388061",
     "geom:latitude":-9.657864,
     "geom:longitude":-76.622493,
@@ -142,12 +142,13 @@
         "qs_pg:id":1330539,
         "wd:id":"Q2088810"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009095,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"08c81538ac75daf51df789062118c090",
+    "wof:geomhash":"15d300e587b815788d2a5acb0c7d2249",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":421176081,
-    "wof:lastmodified":1690850482,
+    "wof:lastmodified":1695886756,
     "wof:name":"Dos De Mayo",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/177/057/421177057.geojson
+++ b/data/421/177/057/421177057.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.400454,
-    "geom:area_square_m":4931864755.917158,
+    "geom:area_square_m":4931864851.486294,
     "geom:bbox":"-79.378418,-5.512791,-78.589508,-4.623749",
     "geom:latitude":-5.125029,
     "geom:longitude":-78.944936,
@@ -163,12 +163,13 @@
         "qs_pg:id":484382,
         "wd:id":"Q1814197"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009131,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"78b1195c6629ec1a12b327d1fed8eaa4",
+    "wof:geomhash":"2fdc39ee651ca452ae297d0e119aebf2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421177057,
-    "wof:lastmodified":1690850477,
+    "wof:lastmodified":1695886752,
     "wof:name":"San Ignacio",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/177/079/421177079.geojson
+++ b/data/421/177/079/421177079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.204604,
-    "geom:area_square_m":2506614820.571261,
+    "geom:area_square_m":2506614770.032489,
     "geom:bbox":"-78.273502,-8.012268,-77.62342,-7.478361",
     "geom:latitude":-7.789545,
     "geom:longitude":-77.905825,
@@ -166,12 +166,13 @@
         "qs_pg:id":484384,
         "wd:id":"Q1944245"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009132,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b3c6f8a845a185a2451df3342293a69b",
+    "wof:geomhash":"b78f61690a16917f9d266a86929c127b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421177079,
-    "wof:lastmodified":1690850476,
+    "wof:lastmodified":1695886754,
     "wof:name":"S\u00e1nchez Carri\u00f3n",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/177/937/421177937.geojson
+++ b/data/421/177/937/421177937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.540156,
-    "geom:area_square_m":6490264047.515477,
+    "geom:area_square_m":6490263181.031245,
     "geom:bbox":"-75.566186,-14.130258,-74.633682,-13.141203",
     "geom:latitude":-13.656134,
     "geom:longitude":-75.092497,
@@ -158,12 +158,13 @@
         "wd:id":"Q629736",
         "wk:page":"Huaytar\u00e1 Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009165,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3bce30334ead31532ecaf5bcc3f53fc8",
+    "wof:geomhash":"1f6a0df129f160ce303ea8a53092b6bf",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421177937,
-    "wof:lastmodified":1690850475,
+    "wof:lastmodified":1695886754,
     "wof:name":"Huaytar\u00e1",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/180/077/421180077.geojson
+++ b/data/421/180/077/421180077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.436128,
-    "geom:area_square_m":5210475807.046856,
+    "geom:area_square_m":5210476277.798488,
     "geom:bbox":"-75.5045,-15.442959,-74.647004,-14.544951",
     "geom:latitude":-14.940144,
     "geom:longitude":-75.078849,
@@ -170,12 +170,13 @@
         "wd:id":"Q938322",
         "wk:page":"Nazca Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009243,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"046934b16fdf028a51035c99b4577d50",
+    "wof:geomhash":"85eb8cb8de6573876cbab08c4f43cca4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421180077,
-    "wof:lastmodified":1690850439,
+    "wof:lastmodified":1695886747,
     "wof:name":"Nazca",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/181/301/421181301.geojson
+++ b/data/421/181/301/421181301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.158696,
-    "geom:area_square_m":1931283637.938568,
+    "geom:area_square_m":1931283631.394173,
     "geom:bbox":"-76.916291,-10.485111,-76.472633,-9.868693",
     "geom:latitude":-10.200651,
     "geom:longitude":-76.703776,
@@ -157,12 +157,13 @@
         "qs_pg:id":485414,
         "wd:id":"Q188098"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009292,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"769397bc1927fe55456030153967591a",
+    "wof:geomhash":"2bbdba460988cbd85398590efe3528ef",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":421181301,
-    "wof:lastmodified":1690850457,
+    "wof:lastmodified":1695886751,
     "wof:name":"Lauricocha",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/182/239/421182239.geojson
+++ b/data/421/182/239/421182239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.301405,
-    "geom:area_square_m":3652129820.199249,
+    "geom:area_square_m":3652129932.967041,
     "geom:bbox":"-76.519227,-11.939682,-75.700652,-11.070422",
     "geom:latitude":-11.497288,
     "geom:longitude":-76.122582,
@@ -107,12 +107,13 @@
         "qs_pg:id":896555,
         "wd:id":"Q1182544"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009323,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e85481df074dc5c9eeb6c9ab6f45f201",
+    "wof:geomhash":"429b6be699bf545cef670161c3809fc6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":421182239,
-    "wof:lastmodified":1690850481,
+    "wof:lastmodified":1695886137,
     "wof:name":"Yauli",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/182/241/421182241.geojson
+++ b/data/421/182/241/421182241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.896095,
-    "geom:area_square_m":122225513416.324615,
+    "geom:area_square_m":122225513271.50325,
     "geom:bbox":"-75.781578,-4.709053,-70.059015,-0.038777",
     "geom:latitude":-2.571534,
     "geom:longitude":-73.481772,
@@ -164,12 +164,13 @@
         "wd:id":"Q1779677",
         "wk:page":"Maynas Province, Peru"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009323,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9ca489fb8e44dcaa3e8bd94f856a6afe",
+    "wof:geomhash":"ed373dda06da9f750c0d47434ebe4620",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421182241,
-    "wof:lastmodified":1690850480,
+    "wof:lastmodified":1695886755,
     "wof:name":"Maynas",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/182/363/421182363.geojson
+++ b/data/421/182/363/421182363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.655541,
-    "geom:area_square_m":7854659962.901884,
+    "geom:area_square_m":7854659932.2582,
     "geom:bbox":"-76.071754,-14.929574,-75.210305,-13.742186",
     "geom:latitude":-14.299664,
     "geom:longitude":-75.643786,
@@ -149,12 +149,13 @@
         "wd:id":"Q2084696",
         "wk:page":"Ica Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009327,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"668cdfa5a76b2dd11149b45e110ff9bd",
+    "wof:geomhash":"aa6a8b3b944a6502ec1f0f9e75dfce9b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421182363,
-    "wof:lastmodified":1690850480,
+    "wof:lastmodified":1695886753,
     "wof:name":"Ica",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/182/365/421182365.geojson
+++ b/data/421/182/365/421182365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32561,
-    "geom:area_square_m":3851099199.656461,
+    "geom:area_square_m":3851099935.398127,
     "geom:bbox":"-72.221008,-17.284939,-71.304908,-16.676762",
     "geom:latitude":-16.960874,
     "geom:longitude":-71.720858,
@@ -149,12 +149,13 @@
         "wd:id":"Q1779688",
         "wk:page":"Islay Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009327,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3648e07c881cdd0bc9e93b8f56146ec9",
+    "wof:geomhash":"6313923f4f03e31632f4b32d712bf827",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421182365,
-    "wof:lastmodified":1690850480,
+    "wof:lastmodified":1695886755,
     "wof:name":"Islay",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/183/001/421183001.geojson
+++ b/data/421/183/001/421183001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120407,
-    "geom:area_square_m":1449172146.121911,
+    "geom:area_square_m":1449172437.627762,
     "geom:bbox":"-72.60067,-13.4535,-71.969062,-13.083662",
     "geom:latitude":-13.257138,
     "geom:longitude":-72.289787,
@@ -185,12 +185,13 @@
         "wd:id":"Q1771879",
         "wk:page":"Urubamba Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009354,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"350274684069e13872209668db7a0895",
+    "wof:geomhash":"fcbc204bf00631b3d70605ba1297ac7b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -200,7 +201,7 @@
         }
     ],
     "wof:id":421183001,
-    "wof:lastmodified":1690850479,
+    "wof:lastmodified":1695886752,
     "wof:name":"Urubamba",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/183/855/421183855.geojson
+++ b/data/421/183/855/421183855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077195,
-    "geom:area_square_m":930832879.230887,
+    "geom:area_square_m":930833036.449753,
     "geom:bbox":"-74.795631,-12.967221,-74.319535,-12.5894",
     "geom:latitude":-12.792479,
     "geom:longitude":-74.583015,
@@ -134,12 +134,13 @@
         "wd:id":"Q1948039",
         "wk:page":"Acobamba Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de9a2e8b9557cfa8ab2b7ba0f105261a",
+    "wof:geomhash":"58d72cd57693f79d9c03a3f053746a59",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421183855,
-    "wof:lastmodified":1690850479,
+    "wof:lastmodified":1695886754,
     "wof:name":"Acobamba",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/183/857/421183857.geojson
+++ b/data/421/183/857/421183857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.979288,
-    "geom:area_square_m":11759794753.225237,
+    "geom:area_square_m":11759794796.931883,
     "geom:bbox":"-70.881637,-14.518025,-69.633477,-13.114535",
     "geom:latitude":-13.791711,
     "geom:longitude":-70.179795,
@@ -155,12 +155,13 @@
         "wd:id":"Q1944216",
         "wk:page":"Carabaya Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b42cef906b95d15452719152847681cb",
+    "wof:geomhash":"25e69e78c2c2e8f53269e7c757fcd5be",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421183857,
-    "wof:lastmodified":1690850478,
+    "wof:lastmodified":1695886754,
     "wof:name":"Carabaya",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/183/859/421183859.geojson
+++ b/data/421/183/859/421183859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217131,
-    "geom:area_square_m":2665979056.016019,
+    "geom:area_square_m":2665979115.064548,
     "geom:bbox":"-78.454322,-7.153174,-77.950936,-6.388402",
     "geom:latitude":-6.798982,
     "geom:longitude":-78.208055,
@@ -167,12 +167,13 @@
         "wd:id":"Q1431153",
         "wk:page":"Celend\u00edn Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dfa32eac66a1f9b3d7a5d1ab82141096",
+    "wof:geomhash":"b815c3ea0344c1d5af5c114ba72b8c44",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421183859,
-    "wof:lastmodified":1690850478,
+    "wof:lastmodified":1695886754,
     "wof:name":"Celend\u00edn",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/183/861/421183861.geojson
+++ b/data/421/183/861/421183861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.237608,
-    "geom:area_square_m":2836334234.033811,
+    "geom:area_square_m":2836333686.159026,
     "geom:bbox":"-70.031143,-15.536365,-69.119623,-14.763004",
     "geom:latitude":-15.121081,
     "geom:longitude":-69.607648,
@@ -155,12 +155,13 @@
         "wd:id":"Q1944227",
         "wk:page":"Huancan\u00e9 Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27760e58d19108ea21b9ea3e22fff917",
+    "wof:geomhash":"c2e325e2cade2531227c659bc1f992b4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421183861,
-    "wof:lastmodified":1690850478,
+    "wof:lastmodified":1695886754,
     "wof:name":"Huancan\u00e9",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/184/147/421184147.geojson
+++ b/data/421/184/147/421184147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.218475,
-    "geom:area_square_m":2651526150.391564,
+    "geom:area_square_m":2651526814.787052,
     "geom:bbox":"-76.278984,-11.386857,-75.459152,-10.727215",
     "geom:latitude":-11.034886,
     "geom:longitude":-75.928789,
@@ -164,12 +164,13 @@
         "wd:id":"Q644721",
         "wk:page":"Jun\u00edn Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009402,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"52b65af6a59e0189ab5b6e9f1daad2b8",
+    "wof:geomhash":"a8a31e742ec3b8da036e16efd33b3c6e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421184147,
-    "wof:lastmodified":1690850470,
+    "wof:lastmodified":1695886753,
     "wof:name":"Jun\u00edn",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/184/497/421184497.geojson
+++ b/data/421/184/497/421184497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.323025,
-    "geom:area_square_m":3932421277.718281,
+    "geom:area_square_m":3932421107.916513,
     "geom:bbox":"-78.243785,-10.611639,-77.550254,-9.688881",
     "geom:latitude":-10.093903,
     "geom:longitude":-77.926775,
@@ -167,12 +167,13 @@
         "wd:id":"Q1779624",
         "wk:page":"Huarmey Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009412,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9fd4dbabd9070a41b305eeb3164734b9",
+    "wof:geomhash":"443685b51b451bde07017244c33a71de",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421184497,
-    "wof:lastmodified":1690850469,
+    "wof:lastmodified":1695886751,
     "wof:name":"Huarmey",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/184/599/421184599.geojson
+++ b/data/421/184/599/421184599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09362,
-    "geom:area_square_m":1148637532.227779,
+    "geom:area_square_m":1148637524.066081,
     "geom:bbox":"-79.690151,-7.325254,-79.251297,-6.946238",
     "geom:latitude":-7.14364,
     "geom:longitude":-79.456994,
@@ -159,12 +159,13 @@
         "qs_pg:id":1002209,
         "wd:id":"Q1920599"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c03ab761525725ece45c7425c0c31623",
+    "wof:geomhash":"2139db53a6d126bd25924704d22b2022",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421184599,
-    "wof:lastmodified":1690850470,
+    "wof:lastmodified":1695886753,
     "wof:name":"Chep\u00e9n",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/184/603/421184603.geojson
+++ b/data/421/184/603/421184603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10132,
-    "geom:area_square_m":1222606206.397071,
+    "geom:area_square_m":1222606172.116899,
     "geom:bbox":"-74.709244,-12.839389,-74.285049,-12.360262",
     "geom:latitude":-12.612705,
     "geom:longitude":-74.489429,
@@ -141,12 +141,13 @@
         "qs_pg:id":1002210,
         "wd:id":"Q639598"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009416,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"59bf790a3ae81e63fc6fbc0bb3eff6fa",
+    "wof:geomhash":"fcb03afd740ded6d996f87997a9f8d52",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -156,7 +157,7 @@
         }
     ],
     "wof:id":421184603,
-    "wof:lastmodified":1690850470,
+    "wof:lastmodified":1695886753,
     "wof:name":"Churcampa",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/185/275/421185275.geojson
+++ b/data/421/185/275/421185275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.411206,
-    "geom:area_square_m":5059385638.40514,
+    "geom:area_square_m":5059385681.940894,
     "geom:bbox":"-79.420434,-6.133926,-78.51207,-5.326244",
     "geom:latitude":-5.710993,
     "geom:longitude":-79.004665,
@@ -170,12 +170,13 @@
         "wd:id":"Q683949",
         "wk:page":"Ja\u00e9n Province, Peru"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009437,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"802d21778ed1fadafc886fcf3fb1790b",
+    "wof:geomhash":"5927365ebedb814cfba5598688788db3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421185275,
-    "wof:lastmodified":1690850486,
+    "wof:lastmodified":1695886757,
     "wof:name":"Ja\u00e9n",
     "wof:parent_id":85675871,
     "wof:placetype":"county",

--- a/data/421/185/309/421185309.geojson
+++ b/data/421/185/309/421185309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272009,
-    "geom:area_square_m":3339740962.563411,
+    "geom:area_square_m":3339741658.415683,
     "geom:bbox":"-79.942464,-7.177658,-79.12175,-6.481246",
     "geom:latitude":-6.80566,
     "geom:longitude":-79.550413,
@@ -162,12 +162,13 @@
         "wd:id":"Q546559",
         "wk:page":"Chiclayo Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009438,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a18f2c4eedc38032402f494c0ac331b0",
+    "wof:geomhash":"afbaa266ab8994b26b42079e69b6314e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":421185309,
-    "wof:lastmodified":1690850486,
+    "wof:lastmodified":1695886757,
     "wof:name":"Chiclayo",
     "wof:parent_id":85675821,
     "wof:placetype":"county",

--- a/data/421/185/311/421185311.geojson
+++ b/data/421/185/311/421185311.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.246884,
-    "geom:area_square_m":2971234359.537777,
+    "geom:area_square_m":2971234325.181072,
     "geom:bbox":"-74.687393,-13.539152,-73.8275,-12.980586",
     "geom:latitude":-13.271229,
     "geom:longitude":-74.230146,
@@ -164,12 +164,13 @@
         "wd:id":"Q1784857",
         "wk:page":"Huamanga Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009438,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68a8d7adeebf8776ad4b0f2e67d6f1d5",
+    "wof:geomhash":"b24fd19b28ea79bf6026e686bc03858c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421185311,
-    "wof:lastmodified":1690850487,
+    "wof:lastmodified":1695886757,
     "wof:name":"Huamanga",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/185/313/421185313.geojson
+++ b/data/421/185/313/421185313.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.33402,
-    "geom:area_square_m":4070353249.607587,
+    "geom:area_square_m":4070352905.915888,
     "geom:bbox":"-76.606391,-10.233115,-75.721963,-9.391178",
     "geom:latitude":-9.765851,
     "geom:longitude":-76.18305,
@@ -168,12 +168,13 @@
         "wd:id":"Q2100624",
         "wk:page":"Hu\u00e1nuco Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009439,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3fd83bde760f29b58951069ef4ef0352",
+    "wof:geomhash":"65dc1fd1c83699bf79e28679aa9472e5",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421185313,
-    "wof:lastmodified":1690850487,
+    "wof:lastmodified":1695886758,
     "wof:name":"Hu\u00e1nuco",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/185/587/421185587.geojson
+++ b/data/421/185/587/421185587.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.115872,
-    "geom:area_square_m":1365886538.799234,
+    "geom:area_square_m":1365886818.951956,
     "geom:bbox":"-71.490983,-17.821566,-70.907182,-17.250941",
     "geom:latitude":-17.57615,
     "geom:longitude":-71.210881,
@@ -140,12 +140,13 @@
         "hasc:id":"PE.MQ.IL",
         "qs_pg:id":1030738
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009448,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"533eccd229eb4845aa7cc8fb46f23b0d",
+    "wof:geomhash":"e02f6fb2997a8e102ba6d821cd9c9441",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421185587,
-    "wof:lastmodified":1636500287,
+    "wof:lastmodified":1695886753,
     "wof:name":"Ilo",
     "wof:parent_id":85675857,
     "wof:placetype":"county",

--- a/data/421/186/269/421186269.geojson
+++ b/data/421/186/269/421186269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.332764,
-    "geom:area_square_m":3943064223.232286,
+    "geom:area_square_m":3943064161.146131,
     "geom:bbox":"-69.686408,-17.175411,-69.01258,-16.174723",
     "geom:latitude":-16.605292,
     "geom:longitude":-69.358675,
@@ -104,12 +104,13 @@
         "hasc:id":"PE.PU.CC",
         "qs_pg:id":1063139
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009475,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0b28dbc8543a96f34ad43b33455ff56e",
+    "wof:geomhash":"64815cc60594311ab3d5a42a7dbbb704",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":421186269,
-    "wof:lastmodified":1627522494,
+    "wof:lastmodified":1695886130,
     "wof:name":"Chucuito",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/187/177/421187177.geojson
+++ b/data/421/187/177/421187177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.237973,
-    "geom:area_square_m":2933558951.234808,
+    "geom:area_square_m":2933558689.9688,
     "geom:bbox":"-81.328231,-4.816401,-80.828518,-4.087144",
     "geom:latitude":-4.486109,
     "geom:longitude":-81.080719,
@@ -171,12 +171,13 @@
         "qs_pg:id":1086777,
         "wd:id":"Q2287241"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009504,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29b1c810c0a32c410fd2a2f98b7ac5c5",
+    "wof:geomhash":"5c3cf4f4ffd7435d0ee75ced7175dbb6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421187177,
-    "wof:lastmodified":1690850443,
+    "wof:lastmodified":1695886748,
     "wof:name":"Talara",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/187/837/421187837.geojson
+++ b/data/421/187/837/421187837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.1621,
-    "geom:area_square_m":1949096568.774389,
+    "geom:area_square_m":1949096780.527339,
     "geom:bbox":"-72.772766,-13.713797,-72.000115,-13.285025",
     "geom:latitude":-13.489196,
     "geom:longitude":-72.36903,
@@ -143,12 +143,13 @@
         "wd:id":"Q1920482",
         "wk:page":"Anta Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009525,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ecd74709373a2be6f604f89504eb9fc",
+    "wof:geomhash":"482dfdba6e89c59a441b9555326527b3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421187837,
-    "wof:lastmodified":1690850442,
+    "wof:lastmodified":1695886748,
     "wof:name":"Anta",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/187/839/421187839.geojson
+++ b/data/421/187/839/421187839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.178967,
-    "geom:area_square_m":2143055693.449755,
+    "geom:area_square_m":2143055939.663907,
     "geom:bbox":"-71.65232,-14.659344,-70.962311,-14.083873",
     "geom:latitude":-14.439584,
     "geom:longitude":-71.343649,
@@ -155,12 +155,13 @@
         "wd:id":"Q1920500",
         "wk:page":"Canas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009525,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a468ac9bd23481d197bbf90f00f0d09e",
+    "wof:geomhash":"8c5f9d4fb824f50b063416d13b140436",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421187839,
-    "wof:lastmodified":1690850442,
+    "wof:lastmodified":1695886748,
     "wof:name":"Canas",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/187/843/421187843.geojson
+++ b/data/421/187/843/421187843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330577,
-    "geom:area_square_m":3964769348.520086,
+    "geom:area_square_m":3964769558.901124,
     "geom:bbox":"-71.517723,-14.473256,-70.789818,-13.725713",
     "geom:latitude":-14.083084,
     "geom:longitude":-71.126541,
@@ -155,12 +155,13 @@
         "wd:id":"Q951287",
         "wk:page":"Canchis Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009525,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d1338630a91b524ab622e4d9c51a3b16",
+    "wof:geomhash":"1da3e1b44c469bcf1d918b3cfc90e88f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421187843,
-    "wof:lastmodified":1690850439,
+    "wof:lastmodified":1695886748,
     "wof:name":"Canchis",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/187/849/421187849.geojson
+++ b/data/421/187/849/421187849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.38725,
-    "geom:area_square_m":4699963994.23346,
+    "geom:area_square_m":4699962964.46333,
     "geom:bbox":"-75.671035,-11.350232,-74.623779,-10.653096",
     "geom:latitude":-11.028646,
     "geom:longitude":-75.129842,
@@ -164,12 +164,13 @@
         "qs_pg:id":1086205,
         "wd:id":"Q765311"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c041609d3aab66049ef47812691c3a91",
+    "wof:geomhash":"f345e9c2ba3c477ea1898c16ba0c5a56",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421187849,
-    "wof:lastmodified":1690850441,
+    "wof:lastmodified":1695886749,
     "wof:name":"Chanchamayo",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/187/851/421187851.geojson
+++ b/data/421/187/851/421187851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.229452,
-    "geom:area_square_m":2798830937.937475,
+    "geom:area_square_m":2798831424.114912,
     "geom:bbox":"-77.335334,-9.841219,-76.726387,-9.070922",
     "geom:latitude":-9.43382,
     "geom:longitude":-77.082247,
@@ -152,12 +152,13 @@
         "wd:id":"Q1779705",
         "wk:page":"Huari Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4a24dd7d4b1bbbd70f40d2a56e7247e",
+    "wof:geomhash":"58f50287582237c48c678765c50a1d70",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421187851,
-    "wof:lastmodified":1690850440,
+    "wof:lastmodified":1695886748,
     "wof:name":"Huari",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/187/855/421187855.geojson
+++ b/data/421/187/855/421187855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.763658,
-    "geom:area_square_m":9387676926.362698,
+    "geom:area_square_m":9387677048.525099,
     "geom:bbox":"-80.62777,-6.820898,-79.402305,-5.480387",
     "geom:latitude":-6.188007,
     "geom:longitude":-79.971445,
@@ -149,12 +149,13 @@
         "wd:id":"Q632826",
         "wk:page":"Lambayeque Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4060033de06d0156436c59c6b3dfc75",
+    "wof:geomhash":"d7f6dc2b04dfa5d7ad5373b920894ea4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421187855,
-    "wof:lastmodified":1690850443,
+    "wof:lastmodified":1695886749,
     "wof:name":"Lambayeque",
     "wof:parent_id":85675821,
     "wof:placetype":"county",

--- a/data/421/187/857/421187857.geojson
+++ b/data/421/187/857/421187857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.481312,
-    "geom:area_square_m":5738154532.281803,
+    "geom:area_square_m":5738155451.239679,
     "geom:bbox":"-71.038971,-15.85115,-70.148086,-14.912066",
     "geom:latitude":-15.387116,
     "geom:longitude":-70.639869,
@@ -137,12 +137,13 @@
         "wd:id":"Q1944347",
         "wk:page":"Lampa Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"46fc1d479b4185056da0238f9c579c5a",
+    "wof:geomhash":"b3a811e799897fd4018db38fc438afa6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421187857,
-    "wof:lastmodified":1690850440,
+    "wof:lastmodified":1695886748,
     "wof:name":"Lampa",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/187/861/421187861.geojson
+++ b/data/421/187/861/421187861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.548765,
-    "geom:area_square_m":6566502601.094304,
+    "geom:area_square_m":6566502601.095149,
     "geom:bbox":"-71.118171875,-15.1945664062,-70.2661894531,-14.0747207031",
     "geom:latitude":-14.596689,
     "geom:longitude":-70.686258,
@@ -326,12 +326,13 @@
         "qs_pg:id":1086211,
         "wd:id":"Q439017"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"89f5696591e80c0bba11f98298eacae5",
+    "wof:geomhash":"8a1596ea802253b4899baa74eac71765",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -341,7 +342,7 @@
         }
     ],
     "wof:id":421187861,
-    "wof:lastmodified":1582343536,
+    "wof:lastmodified":1695886748,
     "wof:name":"Melgar",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/187/863/421187863.geojson
+++ b/data/421/187/863/421187863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.144095,
-    "geom:area_square_m":1777829977.048629,
+    "geom:area_square_m":1777829441.449909,
     "geom:bbox":"-80.665906,-4.231936,-80.179351,-3.484952",
     "geom:latitude":-3.806797,
     "geom:longitude":-80.431571,
@@ -149,12 +149,13 @@
         "qs_pg:id":1086212,
         "wd:id":"Q1178003"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"23bcb091e503cf7dcd6415457df450ae",
+    "wof:geomhash":"172fdf94c23e82286133e63794925914",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421187863,
-    "wof:lastmodified":1690850443,
+    "wof:lastmodified":1695886749,
     "wof:name":"Tumbes",
     "wof:parent_id":85675831,
     "wof:placetype":"county",

--- a/data/421/187/865/421187865.geojson
+++ b/data/421/187/865/421187865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.446153,
-    "geom:area_square_m":29999522496.405087,
+    "geom:area_square_m":29999523812.710052,
     "geom:bbox":"-76.215881,-8.716139,-74.495346,-5.865937",
     "geom:latitude":-7.310787,
     "geom:longitude":-75.365736,
@@ -164,12 +164,13 @@
         "wd:id":"Q2013418",
         "wk:page":"Ucayali Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a30696d2c7b535211b559ebcd83b5c47",
+    "wof:geomhash":"620bc10b9100200e6d6b0a9a04319c30",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421187865,
-    "wof:lastmodified":1690850442,
+    "wof:lastmodified":1695886749,
     "wof:name":"Ucayali",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/187/867/421187867.geojson
+++ b/data/421/187/867/421187867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112111,
-    "geom:area_square_m":1368426883.110695,
+    "geom:area_square_m":1368427158.000235,
     "geom:bbox":"-78.061896,-9.446889,-77.357871,-8.901373",
     "geom:latitude":-9.201438,
     "geom:longitude":-77.742954,
@@ -158,12 +158,13 @@
         "wd:id":"Q1798739",
         "wk:page":"Yungay Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009526,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7a1b85764d41682f6b86741780136ee2",
+    "wof:geomhash":"3762ea544a5fa34206d4f91506dec6f4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421187867,
-    "wof:lastmodified":1690850441,
+    "wof:lastmodified":1695886748,
     "wof:name":"Yungay",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/187/921/421187921.geojson
+++ b/data/421/187/921/421187921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.205985,
-    "geom:area_square_m":2511655667.748049,
+    "geom:area_square_m":2511655122.72302,
     "geom:bbox":"-78.041695,-9.800457,-77.267098,-9.346609",
     "geom:latitude":-9.56129,
     "geom:longitude":-77.646309,
@@ -287,12 +287,13 @@
         "qs_pg:id":1086764,
         "wd:id":"Q793809"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53fc30d00c3201978076e00fd702092a",
+    "wof:geomhash":"de4dc32d685252fce9212fd713dff4f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -302,7 +303,7 @@
         }
     ],
     "wof:id":421187921,
-    "wof:lastmodified":1690850444,
+    "wof:lastmodified":1695886749,
     "wof:name":"Huaraz",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/187/925/421187925.geojson
+++ b/data/421/187/925/421187925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.405228,
-    "geom:area_square_m":4948212677.467731,
+    "geom:area_square_m":4948212785.591775,
     "geom:bbox":"-76.479316,-9.617203,-75.621635,-8.314332",
     "geom:latitude":-9.05471,
     "geom:longitude":-76.036716,
@@ -98,12 +98,13 @@
         "hasc:id":"PE.HC.LP",
         "qs_pg:id":1086769
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009528,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c3f9fba6336adf9894940d1e8d2c2c33",
+    "wof:geomhash":"49927a86c998a500e5960eaff841c19e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":421187925,
-    "wof:lastmodified":1627522495,
+    "wof:lastmodified":1695886133,
     "wof:name":"Leoncio Prado",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/187/933/421187933.geojson
+++ b/data/421/187/933/421187933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011476,
-    "geom:area_square_m":138833281.902544,
+    "geom:area_square_m":138833281.902864,
     "geom:bbox":"-77.187287,-12.079503,-77.076867,-11.81966",
     "geom:latitude":-11.94011,
     "geom:longitude":-77.125126,
@@ -254,6 +254,7 @@
         "hasc:id":"PE.CL.CL",
         "qs_pg:id":1086775
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85675817
     ],
@@ -262,7 +263,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b87ae8d38009300fb7b2c2a5a574efb8",
+    "wof:geomhash":"bfb4df49bdcc227c6515c791286d11b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -272,7 +273,7 @@
         }
     ],
     "wof:id":421187933,
-    "wof:lastmodified":1636500275,
+    "wof:lastmodified":1695886748,
     "wof:name":"Callao",
     "wof:parent_id":85675817,
     "wof:placetype":"county",

--- a/data/421/188/085/421188085.geojson
+++ b/data/421/188/085/421188085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.607939,
-    "geom:area_square_m":19796261807.332626,
+    "geom:area_square_m":19796261347.252384,
     "geom:bbox":"-76.894537,-6.178035,-75.416611,-3.669764",
     "geom:latitude":-5.307404,
     "geom:longitude":-76.109434,
@@ -164,12 +164,13 @@
         "wd:id":"Q1920572",
         "wk:page":"Alto Amazonas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009533,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d3714dea8b9a2626f34366efa83bb5f0",
+    "wof:geomhash":"b27a573966694753271bf58342e28a33",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421188085,
-    "wof:lastmodified":1690850446,
+    "wof:lastmodified":1695886749,
     "wof:name":"Alto Amazonas",
     "wof:parent_id":85675899,
     "wof:placetype":"county",

--- a/data/421/188/283/421188283.geojson
+++ b/data/421/188/283/421188283.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096693,
-    "geom:area_square_m":1168594671.390131,
+    "geom:area_square_m":1168594470.915732,
     "geom:bbox":"-75.665475,-12.411273,-75.231162,-12.010516",
     "geom:latitude":-12.207769,
     "geom:longitude":-75.432889,
@@ -170,12 +170,13 @@
         "qs_pg:id":15534,
         "wd:id":"Q1777631"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009540,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b9f92f411db22d5776595ef0650a13ca",
+    "wof:geomhash":"6adaa9141c0e08a8c25b08516f8ac42c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421188283,
-    "wof:lastmodified":1690850447,
+    "wof:lastmodified":1695886749,
     "wof:name":"Chupaca",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/188/715/421188715.geojson
+++ b/data/421/188/715/421188715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.361594,
-    "geom:area_square_m":4378457320.366801,
+    "geom:area_square_m":4378458577.231122,
     "geom:bbox":"-76.053551,-12.059133,-74.973297,-11.257387",
     "geom:latitude":-11.687215,
     "geom:longitude":-75.490028,
@@ -174,12 +174,13 @@
         "hasc:id":"PE.JU.JJ",
         "qs_pg:id":1103761
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63642b283fd4ea2990c7c8bcb74d405f",
+    "wof:geomhash":"d40b5ea802e30878067ce9ecb1865999",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -189,7 +190,7 @@
         }
     ],
     "wof:id":421188715,
-    "wof:lastmodified":1636500277,
+    "wof:lastmodified":1695886749,
     "wof:name":"Jauja",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/421/188/717/421188717.geojson
+++ b/data/421/188/717/421188717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.170448,
-    "geom:area_square_m":2087913488.701799,
+    "geom:area_square_m":2087913034.674354,
     "geom:bbox":"-78.914268,-8.098738,-78.251728,-7.622699",
     "geom:latitude":-7.840145,
     "geom:longitude":-78.556568,
@@ -200,12 +200,13 @@
         "wd:id":"Q583300",
         "wk:page":"Otuzco Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81ee4e774bcb7404078f4c3a52bb2804",
+    "wof:geomhash":"8a1855f74f99e298ff0a7e75260e0caa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -215,7 +216,7 @@
         }
     ],
     "wof:id":421188717,
-    "wof:lastmodified":1690850447,
+    "wof:lastmodified":1695886749,
     "wof:name":"Otuzco",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/188/719/421188719.geojson
+++ b/data/421/188/719/421188719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057451,
-    "geom:area_square_m":700056019.318814,
+    "geom:area_square_m":700055751.092803,
     "geom:bbox":"-77.961402,-9.913664,-77.478828,-9.620816",
     "geom:latitude":-9.784412,
     "geom:longitude":-77.677441,
@@ -149,12 +149,13 @@
         "wd:id":"Q615891",
         "wk:page":"Aija Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"10c289e7ce71619bdae8f4cc8f0235d7",
+    "wof:geomhash":"48ec50af8e68bc8953ec159280b4ed56",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421188719,
-    "wof:lastmodified":1690850447,
+    "wof:lastmodified":1695886749,
     "wof:name":"Aija",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/188/721/421188721.geojson
+++ b/data/421/188/721/421188721.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162034,
-    "geom:area_square_m":1951860105.647676,
+    "geom:area_square_m":1951860211.821011,
     "geom:bbox":"-74.920525,-13.292434,-74.270713,-12.823246",
     "geom:latitude":-13.046557,
     "geom:longitude":-74.626516,
@@ -152,12 +152,13 @@
         "wd:id":"Q2084862",
         "wk:page":"Angaraes Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5d14897460fd33d5f87b0d1b1c0cf1b2",
+    "wof:geomhash":"66d4f6479e572746a519e7de1d74a00c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421188721,
-    "wof:lastmodified":1690850447,
+    "wof:lastmodified":1695886749,
     "wof:name":"Angaraes",
     "wof:parent_id":85675911,
     "wof:placetype":"county",

--- a/data/421/188/725/421188725.geojson
+++ b/data/421/188/725/421188725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14188,
-    "geom:area_square_m":1740224264.233098,
+    "geom:area_square_m":1740224332.47488,
     "geom:bbox":"-78.003135,-7.674285,-77.486184,-6.940957",
     "geom:latitude":-7.279962,
     "geom:longitude":-77.73944,
@@ -167,12 +167,13 @@
         "wd:id":"Q951816",
         "wk:page":"Bol\u00edvar Province, Peru"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"984929759451f583e6c7e56230f84a31",
+    "wof:geomhash":"2986220449b61e92fd02b34c37f46e50",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421188725,
-    "wof:lastmodified":1690850446,
+    "wof:lastmodified":1695886749,
     "wof:name":"Bol\u00edvar",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/188/727/421188727.geojson
+++ b/data/421/188/727/421188727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128519,
-    "geom:area_square_m":1579359425.71452,
+    "geom:area_square_m":1579359204.79543,
     "geom:bbox":"-79.850887,-6.715187,-79.175494,-5.976193",
     "geom:latitude":-6.365562,
     "geom:longitude":-79.522209,
@@ -164,12 +164,13 @@
         "wd:id":"Q1948067",
         "wk:page":"Ferre\u00f1afe Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009576,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7ac1f424ca977e57ca8853c37fc52064",
+    "wof:geomhash":"21d6f33410c29142c7f301661966742a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421188727,
-    "wof:lastmodified":1690850448,
+    "wof:lastmodified":1695886750,
     "wof:name":"Ferre\u00f1afe",
     "wof:parent_id":85675821,
     "wof:placetype":"county",

--- a/data/421/188/857/421188857.geojson
+++ b/data/421/188/857/421188857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.311257,
-    "geom:area_square_m":3832554665.078518,
+    "geom:area_square_m":3832554896.065538,
     "geom:bbox":"-80.365064,-5.630342,-79.642209,-4.928314",
     "geom:latitude":-5.256572,
     "geom:longitude":-79.988955,
@@ -116,12 +116,13 @@
         "hasc:id":"PE.PI.MO",
         "qs_pg:id":1104697
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009586,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27304c098ff2743cd9c919fca149309e",
+    "wof:geomhash":"27f3ed3876570725b0626faf19e654fd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":421188857,
-    "wof:lastmodified":1627522495,
+    "wof:lastmodified":1695886133,
     "wof:name":"Morrop\u00f3n",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/191/399/421191399.geojson
+++ b/data/421/191/399/421191399.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.261599,
-    "geom:area_square_m":3198990921.396165,
+    "geom:area_square_m":3198990846.875809,
     "geom:bbox":"-78.935521,-8.969465,-78.236045,-8.140701",
     "geom:latitude":-8.521801,
     "geom:longitude":-78.603652,
@@ -167,12 +167,13 @@
         "qs_pg:id":64641,
         "wd:id":"Q1948051"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009690,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cd59be87bbfc61a5adf44b876386deae",
+    "wof:geomhash":"b8e50228daab7b958939363e0a447f2d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421191399,
-    "wof:lastmodified":1690850462,
+    "wof:lastmodified":1695886752,
     "wof:name":"Vir\u00fa",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/192/879/421192879.geojson
+++ b/data/421/192/879/421192879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077698,
-    "geom:area_square_m":932408844.089568,
+    "geom:area_square_m":932408730.653219,
     "geom:bbox":"-71.836715,-14.154182,-71.439498,-13.696398",
     "geom:latitude":-13.952441,
     "geom:longitude":-71.654506,
@@ -137,12 +137,13 @@
         "wd:id":"Q1920602",
         "wk:page":"Acomayo Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f3dd917dc5c6800ed3469dbb45e250a1",
+    "wof:geomhash":"6695cc572d61efc9a711adcd760bc4aa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421192879,
-    "wof:lastmodified":1690850423,
+    "wof:lastmodified":1695886743,
     "wof:name":"Acomayo",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/192/883/421192883.geojson
+++ b/data/421/192/883/421192883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.348505,
-    "geom:area_square_m":4289851690.605933,
+    "geom:area_square_m":4289851282.843793,
     "geom:bbox":"-79.839311,-5.970297,-79.210834,-4.83271",
     "geom:latitude":-5.442589,
     "geom:longitude":-79.514771,
@@ -155,12 +155,13 @@
         "wd:id":"Q1422619",
         "wk:page":"Huancabamba Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009752,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f218777ca4127f42f4c5fcbadd79dce0",
+    "wof:geomhash":"fa8fecc7561da0346dd2e2a1c6ecaffa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421192883,
-    "wof:lastmodified":1690850424,
+    "wof:lastmodified":1695886743,
     "wof:name":"Huancabamba",
     "wof:parent_id":85675827,
     "wof:placetype":"county",

--- a/data/421/193/361/421193361.geojson
+++ b/data/421/193/361/421193361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.216167,
-    "geom:area_square_m":2648691919.249873,
+    "geom:area_square_m":2648691594.429155,
     "geom:bbox":"-79.465707,-7.998842,-78.793758,-7.38843",
     "geom:latitude":-7.724037,
     "geom:longitude":-79.151756,
@@ -173,12 +173,13 @@
         "qs_pg:id":891426,
         "wd:id":"Q927324"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009768,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4b293b2b0d52a0b7978c4eafce6ca682",
+    "wof:geomhash":"9025ecd2c907dc0c465b9f9f40e22212",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -188,7 +189,7 @@
         }
     ],
     "wof:id":421193361,
-    "wof:lastmodified":1690850430,
+    "wof:lastmodified":1695886746,
     "wof:name":"Ascope",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/193/379/421193379.geojson
+++ b/data/421/193/379/421193379.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.185498,
-    "geom:area_square_m":14113099138.55452,
+    "geom:area_square_m":14113098698.831163,
     "geom:bbox":"-72.601318,-16.610699,-70.845879,-14.788533",
     "geom:latitude":-15.680131,
     "geom:longitude":-71.681014,
@@ -143,12 +143,13 @@
         "wd:id":"Q1806435",
         "wk:page":"Caylloma Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009769,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bcc83d2698a08fb4a00aa8435541669c",
+    "wof:geomhash":"1a79b15965499de507a23b5589447b93",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421193379,
-    "wof:lastmodified":1690850429,
+    "wof:lastmodified":1695886745,
     "wof:name":"Caylloma",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/193/431/421193431.geojson
+++ b/data/421/193/431/421193431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.734768,
-    "geom:area_square_m":8687921400.794216,
+    "geom:area_square_m":8687921150.892014,
     "geom:bbox":"-71.442246,-17.64742,-69.994758,-16.461283",
     "geom:latitude":-17.011502,
     "geom:longitude":-70.784554,
@@ -165,12 +165,13 @@
         "wd:id":"Q1944431",
         "wk:page":"Mariscal Nieto Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009770,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1e1134904af00e5d08155a931b03cd2c",
+    "wof:geomhash":"62e6c343907e9443cbaf460f854dc735",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":421193431,
-    "wof:lastmodified":1690850429,
+    "wof:lastmodified":1695886746,
     "wof:name":"Mariscal Nieto",
     "wof:parent_id":85675857,
     "wof:placetype":"county",

--- a/data/421/193/433/421193433.geojson
+++ b/data/421/193/433/421193433.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.213766,
-    "geom:area_square_m":14522521485.940493,
+    "geom:area_square_m":14522520810.87924,
     "geom:bbox":"-75.138611,-15.481781,-73.533088,-14.018811",
     "geom:latitude":-14.616317,
     "geom:longitude":-74.34606,
@@ -149,12 +149,13 @@
         "wd:id":"Q1814203",
         "wk:page":"Lucanas Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009770,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"238622c2c6e8b3981b6b1ef3444f3b9c",
+    "wof:geomhash":"9a867b91d77b69aba20cf2f45e45b2b4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421193433,
-    "wof:lastmodified":1690850431,
+    "wof:lastmodified":1695886746,
     "wof:name":"Lucanas",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/194/075/421194075.geojson
+++ b/data/421/194/075/421194075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.096965,
-    "geom:area_square_m":13058691055.963326,
+    "geom:area_square_m":13058690994.343416,
     "geom:bbox":"-75.075086,-16.405461,-73.194809,-15.099062",
     "geom:latitude":-15.688842,
     "geom:longitude":-73.963457,
@@ -167,12 +167,13 @@
         "wd:id":"Q1779727",
         "wk:page":"Caravel\u00ed Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"545598623103874253b2c87b7795126d",
+    "wof:geomhash":"a7d7a22966fcdfaceda761ab7f7bade6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -182,7 +183,7 @@
         }
     ],
     "wof:id":421194075,
-    "wof:lastmodified":1690850427,
+    "wof:lastmodified":1695886744,
     "wof:name":"Caravel\u00ed",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/194/077/421194077.geojson
+++ b/data/421/194/077/421194077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067176,
-    "geom:area_square_m":819747710.777722,
+    "geom:area_square_m":819747788.647499,
     "geom:bbox":"-77.777123,-9.453719,-77.318656,-9.08243",
     "geom:latitude":-9.29068,
     "geom:longitude":-77.569036,
@@ -149,12 +149,13 @@
         "wd:id":"Q1166126",
         "wk:page":"Carhuaz Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c5d8a240bcc1b65cfbcb5c61d5e58129",
+    "wof:geomhash":"1e944496c4e20f8ddfea8865c3c8259e",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421194077,
-    "wof:lastmodified":1690850426,
+    "wof:lastmodified":1695886744,
     "wof:name":"Carhuaz",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/194/079/421194079.geojson
+++ b/data/421/194/079/421194079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.125888,
-    "geom:area_square_m":1513810737.882457,
+    "geom:area_square_m":1513810975.806118,
     "geom:bbox":"-73.847748,-13.736404,-73.449187,-13.169617",
     "geom:latitude":-13.469999,
     "geom:longitude":-73.672275,
@@ -117,12 +117,13 @@
         "hasc:id":"PE.AP.CH",
         "qs_pg:id":355688
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"785c514651e742ba8090b95d99f69b0b",
+    "wof:geomhash":"ee3907e699583edaf834f9297cff886d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421194079,
-    "wof:lastmodified":1627522494,
+    "wof:lastmodified":1695886131,
     "wof:name":"Chincheros",
     "wof:parent_id":85675835,
     "wof:placetype":"county",

--- a/data/421/194/081/421194081.geojson
+++ b/data/421/194/081/421194081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.321228,
-    "geom:area_square_m":3876855100.684206,
+    "geom:area_square_m":3876855042.896869,
     "geom:bbox":"-74.581596,-13.067748,-73.830467,-12.167912",
     "geom:latitude":-12.567337,
     "geom:longitude":-74.173078,
@@ -170,12 +170,13 @@
         "wd:id":"Q930214",
         "wk:page":"Huanta Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"442a50b4f8e139a462d4c0eb92a27e0e",
+    "wof:geomhash":"ecefa8e1036e65b68658e68edf19d8fd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -185,7 +186,7 @@
         }
     ],
     "wof:id":421194081,
-    "wof:lastmodified":1690850427,
+    "wof:lastmodified":1695886747,
     "wof:name":"Huanta",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/194/085/421194085.geojson
+++ b/data/421/194/085/421194085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.648088,
-    "geom:area_square_m":31984868819.767815,
+    "geom:area_square_m":31984868238.327595,
     "geom:bbox":"-73.980361,-13.457748,-71.945701,-11.192943",
     "geom:latitude":-12.350533,
     "geom:longitude":-72.923812,
@@ -171,12 +171,13 @@
         "wd:id":"Q1343276",
         "wk:page":"La Convenci\u00f3n Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e3350342c764bb8daf55e5c7b105b72",
+    "wof:geomhash":"9326cfbed108be93119b54e21d33ec10",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -186,7 +187,7 @@
         }
     ],
     "wof:id":421194085,
-    "wof:lastmodified":1690850426,
+    "wof:lastmodified":1695886744,
     "wof:name":"La Convenci\u00f3n",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/194/089/421194089.geojson
+++ b/data/421/194/089/421194089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.215872,
-    "geom:area_square_m":2655322043.393569,
+    "geom:area_square_m":2655322505.723701,
     "geom:bbox":"-77.77568,-6.233889,-77.120193,-5.410686",
     "geom:latitude":-5.864624,
     "geom:longitude":-77.46619,
@@ -137,12 +137,13 @@
         "wd:id":"Q2084648",
         "wk:page":"Rioja Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009793,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a4534aac3d955c04a5fffe5b47d2dfd9",
+    "wof:geomhash":"5b6e0f7e0417653a81d655a9ed67bd9b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421194089,
-    "wof:lastmodified":1690850427,
+    "wof:lastmodified":1695886745,
     "wof:name":"Rioja",
     "wof:parent_id":85675885,
     "wof:placetype":"county",

--- a/data/421/194/455/421194455.geojson
+++ b/data/421/194/455/421194455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.090951,
-    "geom:area_square_m":1115191750.386388,
+    "geom:area_square_m":1115192666.265525,
     "geom:bbox":"-79.599773,-7.638045,-79.187129,-7.221434",
     "geom:latitude":-7.427562,
     "geom:longitude":-79.425292,
@@ -146,12 +146,13 @@
         "wd:id":"Q6319125",
         "wk:page":"Pacasmayo District"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009806,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"528ff16eeefb495c10919bc07f3fa766",
+    "wof:geomhash":"461bb211a70d8277a08e9a7a24cdf64a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":421194455,
-    "wof:lastmodified":1690850426,
+    "wof:lastmodified":1695886747,
     "wof:name":"Pacasmayo",
     "wof:parent_id":85675879,
     "wof:placetype":"county",

--- a/data/421/194/457/421194457.geojson
+++ b/data/421/194/457/421194457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.817468,
-    "geom:area_square_m":9972912000.027374,
+    "geom:area_square_m":9972911370.695642,
     "geom:bbox":"-75.76258,-9.998475,-74.510865,-8.62102",
     "geom:latitude":-9.37718,
     "geom:longitude":-75.094354,
@@ -153,12 +153,13 @@
         "qs_pg:id":424722,
         "wd:id":"Q1944276"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009806,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"dcb761c1b19f5d384e17ec6a3348d440",
+    "wof:geomhash":"4d83739c9d48fc2e4727dc92c970f1ba",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -168,7 +169,7 @@
         }
     ],
     "wof:id":421194457,
-    "wof:lastmodified":1690850428,
+    "wof:lastmodified":1695886746,
     "wof:name":"Puerto Inca",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/194/639/421194639.geojson
+++ b/data/421/194/639/421194639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164424,
-    "geom:area_square_m":1973716898.652946,
+    "geom:area_square_m":1973716886.505377,
     "geom:bbox":"-72.233391,-14.278854,-71.6736,-13.593629",
     "geom:latitude":-13.884525,
     "geom:longitude":-71.9161,
@@ -140,12 +140,13 @@
         "wd:id":"Q1920613",
         "wk:page":"Paruro Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009814,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b0ed059e9d2cfa2ba6eb41f60c2d2093",
+    "wof:geomhash":"9e40083efd35c4d3b04c985c1d5f1799",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":421194639,
-    "wof:lastmodified":1690850428,
+    "wof:lastmodified":1695886746,
     "wof:name":"Paruro",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/194/849/421194849.geojson
+++ b/data/421/194/849/421194849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.392943,
-    "geom:area_square_m":4773541208.394595,
+    "geom:area_square_m":4773540393.282971,
     "geom:bbox":"-76.670859,-11.155084,-75.567687,-10.369859",
     "geom:latitude":-10.748988,
     "geom:longitude":-76.149925,
@@ -150,12 +150,13 @@
         "wd:id":"Q1944288",
         "wk:page":"Pasco Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009822,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"947571db840fdfbbbd381c041fe0a60b",
+    "wof:geomhash":"e64d59d0b172aba13cd6eadb2d311941",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":421194849,
-    "wof:lastmodified":1690850428,
+    "wof:lastmodified":1695886748,
     "wof:name":"Pasco",
     "wof:parent_id":85675883,
     "wof:placetype":"county",

--- a/data/421/194/939/421194939.geojson
+++ b/data/421/194/939/421194939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063402,
-    "geom:area_square_m":772533542.435724,
+    "geom:area_square_m":772533661.655215,
     "geom:bbox":"-76.758367,-9.960766,-76.442338,-9.665279",
     "geom:latitude":-9.803162,
     "geom:longitude":-76.595535,
@@ -156,12 +156,13 @@
         "qs_pg:id":61403,
         "wd:id":"Q2088849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009825,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"66b21b50bf5af35a8161c60dba4d8512",
+    "wof:geomhash":"d64ac8d35b55138b572c83419bd15533",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":421194939,
-    "wof:lastmodified":1690850425,
+    "wof:lastmodified":1695886744,
     "wof:name":"Yarowilca",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/197/033/421197033.geojson
+++ b/data/421/197/033/421197033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.102184,
-    "geom:area_square_m":1223983398.337265,
+    "geom:area_square_m":1223983398.337297,
     "geom:bbox":"-75.3636855469,-14.6772753906,-75.0314257812,-14.0329570312",
     "geom:latitude":-14.370752,
     "geom:longitude":-75.174304,
@@ -112,12 +112,13 @@
         "qs_pg:id":1288739,
         "wd:id":"Q446812"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009900,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"de094e4b991a18bceb104820ed3c4605",
+    "wof:geomhash":"655d0c70ef4f9fba649858884898ffbd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":421197033,
-    "wof:lastmodified":1582343545,
+    "wof:lastmodified":1695886752,
     "wof:name":"Palpa",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/197/577/421197577.geojson
+++ b/data/421/197/577/421197577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.217466,
-    "geom:area_square_m":2647728056.052775,
+    "geom:area_square_m":2647728009.416245,
     "geom:bbox":"-76.136711,-10.489615,-75.593666,-9.6125",
     "geom:latitude":-10.050615,
     "geom:longitude":-75.889693,
@@ -147,12 +147,13 @@
         "qs_pg:id":361240,
         "wd:id":"Q2084641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009918,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"995bec8b0ced51224b30fc28815f137a",
+    "wof:geomhash":"2db037dc59ea487ec464f2fb9a5bf8f7",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -162,7 +163,7 @@
         }
     ],
     "wof:id":421197577,
-    "wof:lastmodified":1690850464,
+    "wof:lastmodified":1695886752,
     "wof:name":"Pachitea",
     "wof:parent_id":85675875,
     "wof:placetype":"county",

--- a/data/421/198/069/421198069.geojson
+++ b/data/421/198/069/421198069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.817121,
-    "geom:area_square_m":9695390856.1751,
+    "geom:area_square_m":9695390127.11545,
     "geom:bbox":"-72.28373,-16.799346,-70.804084,-15.921979",
     "geom:latitude":-16.346078,
     "geom:longitude":-71.554958,
@@ -164,12 +164,13 @@
         "wd:id":"Q601118",
         "wk:page":"Arequipa Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009935,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf3aeef3b5929c694218fbbe11478a40",
+    "wof:geomhash":"996e56709199662706dadc165757a8c2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421198069,
-    "wof:lastmodified":1690850461,
+    "wof:lastmodified":1695886750,
     "wof:name":"Arequipa",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/198/071/421198071.geojson
+++ b/data/421/198/071/421198071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330388,
-    "geom:area_square_m":3967301205.570179,
+    "geom:area_square_m":3967301798.306716,
     "geom:bbox":"-76.398364,-14.426694,-75.465615,-13.352926",
     "geom:latitude":-13.803371,
     "geom:longitude":-75.942459,
@@ -263,12 +263,13 @@
         "qs_pg:id":355796,
         "wd:id":"Q388502"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009935,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6814dea70a319017261451178a4004e6",
+    "wof:geomhash":"225b1c82871ee609222089c978f57634",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -278,7 +279,7 @@
         }
     ],
     "wof:id":421198071,
-    "wof:lastmodified":1690850461,
+    "wof:lastmodified":1695886750,
     "wof:name":"Pisco",
     "wof:parent_id":85675915,
     "wof:placetype":"county",

--- a/data/421/198/073/421198073.geojson
+++ b/data/421/198/073/421198073.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024881,
-    "geom:area_square_m":295299084.3996,
+    "geom:area_square_m":295298733.027822,
     "geom:bbox":"-69.204551,-16.420753,-68.956694,-16.189125",
     "geom:latitude":-16.294465,
     "geom:longitude":-69.081487,
@@ -120,12 +120,13 @@
         "hasc:id":"PE.PU.YU",
         "qs_pg:id":355838
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459009935,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d98a1a973ea950edf8366b9fb7a15f06",
+    "wof:geomhash":"cc3c7a3bf21b091154dface854438fa9",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -135,7 +136,7 @@
         }
     ],
     "wof:id":421198073,
-    "wof:lastmodified":1627522498,
+    "wof:lastmodified":1695886137,
     "wof:name":"Yunguyo",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/199/871/421199871.geojson
+++ b/data/421/199/871/421199871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061179,
-    "geom:area_square_m":754952383.496913,
+    "geom:area_square_m":754952797.94629,
     "geom:bbox":"-80.394976,-3.92599,-80.126784,-3.397425",
     "geom:latitude":-3.652925,
     "geom:longitude":-80.256582,
@@ -133,12 +133,13 @@
         "qs_pg:id":504903,
         "wd:id":"Q2877763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010003,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d74479211d9c73c75ba5301a1569524c",
+    "wof:geomhash":"e3a4ac39d36740358de0e84a20c455f1",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421199871,
-    "wof:lastmodified":1690850465,
+    "wof:lastmodified":1695886752,
     "wof:name":"Zarumilla",
     "wof:parent_id":85675831,
     "wof:placetype":"county",

--- a/data/421/200/651/421200651.geojson
+++ b/data/421/200/651/421200651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.546084,
-    "geom:area_square_m":6487986305.468414,
+    "geom:area_square_m":6487986093.774473,
     "geom:bbox":"-70.563033,-16.654613,-69.60907,-15.478591",
     "geom:latitude":-16.086393,
     "geom:longitude":-70.082298,
@@ -152,12 +152,13 @@
         "wd:id":"Q2084681",
         "wk:page":"Puno Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010034,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6e624722fe6d10024f4fe850ed5cf330",
+    "wof:geomhash":"e2f168e2148cd67bfd158912c4fbf324",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -167,7 +168,7 @@
         }
     ],
     "wof:id":421200651,
-    "wof:lastmodified":1690850466,
+    "wof:lastmodified":1695886751,
     "wof:name":"Puno",
     "wof:parent_id":1108805617,
     "wof:placetype":"county",

--- a/data/421/201/039/421201039.geojson
+++ b/data/421/201/039/421201039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.757334,
-    "geom:area_square_m":9254294093.213646,
+    "geom:area_square_m":9254293936.648289,
     "geom:bbox":"-75.945748,-9.400172,-74.962273,-8.215248",
     "geom:latitude":-8.79775,
     "geom:longitude":-75.440448,
@@ -90,12 +90,13 @@
         "hasc:id":"PE.UC.PA",
         "qs_pg:id":909732
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010049,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f8ba5595e8a272d4bad37064b045654f",
+    "wof:geomhash":"b3f0e16e18ef1f10117d14f437fbe8c3",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421201039,
-    "wof:lastmodified":1627522496,
+    "wof:lastmodified":1695886134,
     "wof:name":"Padre Abad",
     "wof:parent_id":85675891,
     "wof:placetype":"county",

--- a/data/421/202/207/421202207.geojson
+++ b/data/421/202/207/421202207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.482835,
-    "geom:area_square_m":5813629963.134226,
+    "geom:area_square_m":5813630236.408281,
     "geom:bbox":"-71.920807,-13.638943,-71.062348,-12.70034",
     "geom:latitude":-13.155247,
     "geom:longitude":-71.526003,
@@ -143,12 +143,13 @@
         "wd:id":"Q746434",
         "wk:page":"Paucartambo Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010109,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5c1e5aba14633ec820b8b9b2f6dc0eb0",
+    "wof:geomhash":"e2adf2fee08129b10d59db894002b86d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":421202207,
-    "wof:lastmodified":1690850435,
+    "wof:lastmodified":1695886747,
     "wof:name":"Paucartambo",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/202/209/421202209.geojson
+++ b/data/421/202/209/421202209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.613022,
-    "geom:area_square_m":7369941416.420741,
+    "geom:area_square_m":7369941371.980756,
     "geom:bbox":"-71.843635,-13.966748,-70.345047,-13.066934",
     "geom:latitude":-13.522891,
     "geom:longitude":-71.030271,
@@ -155,12 +155,13 @@
         "wd:id":"Q1920520",
         "wk:page":"Quispicanchi Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010109,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fb9b48a21ad6a5b9df45d1bbf5d6ce3e",
+    "wof:geomhash":"3c59bf385d91ae3eafebb04cfdb22a8c",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":421202209,
-    "wof:lastmodified":1690850435,
+    "wof:lastmodified":1695886747,
     "wof:name":"Quispicanchi",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/202/211/421202211.geojson
+++ b/data/421/202/211/421202211.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191134,
-    "geom:area_square_m":2327846725.834869,
+    "geom:area_square_m":2327846924.36058,
     "geom:bbox":"-77.775627,-10.251184,-77.173691,-9.646799",
     "geom:latitude":-9.950972,
     "geom:longitude":-77.426223,
@@ -149,12 +149,13 @@
         "wd:id":"Q1779720",
         "wk:page":"Recuay Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010109,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7f92ba5ed9666f1402a6da9a79059236",
+    "wof:geomhash":"fa5efbd6090ab1885ca95b50fb342f62",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -164,7 +165,7 @@
         }
     ],
     "wof:id":421202211,
-    "wof:lastmodified":1690850434,
+    "wof:lastmodified":1695886747,
     "wof:name":"Recuay",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/202/213/421202213.geojson
+++ b/data/421/202/213/421202213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.326538,
-    "geom:area_square_m":3988323020.92711,
+    "geom:area_square_m":3988323177.482877,
     "geom:bbox":"-78.658481,-9.354797,-77.941262,-8.652947",
     "geom:latitude":-8.96914,
     "geom:longitude":-78.28827,
@@ -138,12 +138,13 @@
         "hasc:id":"PE.AN.ST",
         "qs_pg:id":219983
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010109,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"53640a22790c052766115f403580905e",
+    "wof:geomhash":"7377be056dad295aa4fee7ce3de06255",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -153,7 +154,7 @@
         }
     ],
     "wof:id":421202213,
-    "wof:lastmodified":1636500274,
+    "wof:lastmodified":1695886748,
     "wof:name":"Santa",
     "wof:parent_id":85675865,
     "wof:placetype":"county",

--- a/data/421/202/523/421202523.geojson
+++ b/data/421/202/523/421202523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.58303,
-    "geom:area_square_m":6943396790.685581,
+    "geom:area_square_m":6943396416.088297,
     "geom:bbox":"-72.723092,-16.430539,-71.901246,-14.837326",
     "geom:latitude":-15.604359,
     "geom:longitude":-72.323413,
@@ -164,12 +164,13 @@
         "wd:id":"Q614628",
         "wk:page":"Castilla Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010120,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4ec7c24f7759b5e414d0f9220935721",
+    "wof:geomhash":"e4bfd30032dd5e841fc734a4dfe60167",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -179,7 +180,7 @@
         }
     ],
     "wof:id":421202523,
-    "wof:lastmodified":1690850436,
+    "wof:lastmodified":1695886747,
     "wof:name":"Castilla",
     "wof:parent_id":85675839,
     "wof:placetype":"county",

--- a/data/421/202/549/421202549.geojson
+++ b/data/421/202/549/421202549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.223743,
-    "geom:area_square_m":2705973231.283401,
+    "geom:area_square_m":2705973231.283716,
     "geom:bbox":"-77.198996,-12.519679,-76.621551,-11.57301",
     "geom:latitude":-12.017922,
     "geom:longitude":-76.904206,
@@ -637,6 +637,7 @@
         "qs_pg:id":224312,
         "wd:id":"Q2868"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421186805
     ],
@@ -645,7 +646,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e902e8a7dd726bade22f01c2a689211d",
+    "wof:geomhash":"a4caf454c16031793e247d02ae27b3a8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -655,7 +656,7 @@
         }
     ],
     "wof:id":421202549,
-    "wof:lastmodified":1690850435,
+    "wof:lastmodified":1695886457,
     "wof:name":"Lima",
     "wof:parent_id":1175613121,
     "wof:placetype":"county",

--- a/data/421/202/681/421202681.geojson
+++ b/data/421/202/681/421202681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.358651,
-    "geom:area_square_m":4320296266.011045,
+    "geom:area_square_m":4320295882.998963,
     "geom:bbox":"-74.148971,-13.475971,-73.210266,-12.530535",
     "geom:latitude":-13.046099,
     "geom:longitude":-73.721772,
@@ -158,12 +158,13 @@
         "wd:id":"Q514494",
         "wk:page":"La Mar Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010126,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9560276544840685004b3cdb8d515ec9",
+    "wof:geomhash":"34c4e7be42a9a6af68328257343b5bfd",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -173,7 +174,7 @@
         }
     ],
     "wof:id":421202681,
-    "wof:lastmodified":1690850434,
+    "wof:lastmodified":1695886747,
     "wof:name":"La Mar",
     "wof:parent_id":85675903,
     "wof:placetype":"county",

--- a/data/421/203/205/421203205.geojson
+++ b/data/421/203/205/421203205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.439815,
-    "geom:area_square_m":5255402572.879555,
+    "geom:area_square_m":5255402652.268772,
     "geom:bbox":"-71.902236,-15.45866,-70.949592,-14.529641",
     "geom:latitude":-14.904574,
     "geom:longitude":-71.380533,
@@ -137,12 +137,13 @@
         "wd:id":"Q1947973",
         "wk:page":"Espinar Province"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010143,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37f01e679a553c2b9bd835bdb048b8d8",
+    "wof:geomhash":"411ef8ac2a08463d03d7654136d289b2",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":421203205,
-    "wof:lastmodified":1690850433,
+    "wof:lastmodified":1695886747,
     "wof:name":"Espinar",
     "wof:parent_id":85675843,
     "wof:placetype":"county",

--- a/data/421/203/221/421203221.geojson
+++ b/data/421/203/221/421203221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.587738,
-    "geom:area_square_m":19233878131.720383,
+    "geom:area_square_m":19233878125.504574,
     "geom:bbox":"-75.051338,-12.387293,-73.355408,-10.733975",
     "geom:latitude":-11.562358,
     "geom:longitude":-74.100878,
@@ -134,12 +134,13 @@
         "hasc:id":"PE.JU.SO",
         "qs_pg:id":230276
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PE",
     "wof:created":1459010144,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"adc567abca7d0927269237104db4fd97",
+    "wof:geomhash":"c01d607248896a7738352202c7af5bf8",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":421203221,
-    "wof:lastmodified":1636500273,
+    "wof:lastmodified":1695886748,
     "wof:name":"Satipo",
     "wof:parent_id":85675919,
     "wof:placetype":"county",

--- a/data/856/325/21/85632521.geojson
+++ b/data/856/325/21/85632521.geojson
@@ -1152,6 +1152,7 @@
         "hasc:id":"PE",
         "icao:code":"OB",
         "ioc:id":"PER",
+        "iso:code":"PE",
         "itu:id":"PRU",
         "m49:code":"604",
         "marc:id":"pe",
@@ -1165,6 +1166,7 @@
         "wk:page":"Peru",
         "wmo:id":"PR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:country_alpha3":"PER",
     "wof:geom_alt":[
@@ -1189,7 +1191,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1694639524,
+    "wof:lastmodified":1695881179,
     "wof:name":"Peru",
     "wof:parent_id":102191577,
     "wof:placetype":"country",

--- a/data/856/758/17/85675817.geojson
+++ b/data/856/758/17/85675817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011476,
-    "geom:area_square_m":138833281.902544,
+    "geom:area_square_m":138833281.902864,
     "geom:bbox":"-77.187287,-12.079503,-77.076867,-11.81966",
     "geom:latitude":-11.94011,
     "geom:longitude":-77.125126,
@@ -232,10 +232,12 @@
         "gn:id":3946080,
         "gp:id":2346474,
         "hasc:id":"PE.CL",
+        "iso:code":"PE-CAL",
         "iso:id":"PE-CAL",
         "qs_pg:id":219585,
         "wd:id":"Q3199075"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421187933
     ],
@@ -243,7 +245,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b87ae8d38009300fb7b2c2a5a574efb8",
+    "wof:geomhash":"bfb4df49bdcc227c6515c791286d11b0",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -260,7 +262,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850386,
+    "wof:lastmodified":1695884858,
     "wof:name":"Callao",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/21/85675821.geojson
+++ b/data/856/758/21/85675821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.164187,
-    "geom:area_square_m":14306777304.92452,
+    "geom:area_square_m":14306777911.735855,
     "geom:bbox":"-80.62777,-7.177658,-79.12175,-5.480387",
     "geom:latitude":-6.351921,
     "geom:longitude":-79.823479,
@@ -327,17 +327,19 @@
         "gn:id":3695753,
         "gp:id":2346481,
         "hasc:id":"PE.LB",
+        "iso:code":"PE-LAM",
         "iso:id":"PE-LAM",
         "qs_pg:id":423855,
         "unlc:id":"PE-LAM",
         "wd:id":"Q210061",
         "wk:page":"Lambayeque Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6ec3e6160ea7ba45aeea29d1996b1d6e",
+    "wof:geomhash":"70da3d7a331640702b950da9ee93a221",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -354,7 +356,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850386,
+    "wof:lastmodified":1695884858,
     "wof:name":"Lambayeque",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/27/85675827.geojson
+++ b/data/856/758/27/85675827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.918197,
-    "geom:area_square_m":35937940098.922142,
+    "geom:area_square_m":35937939491.58503,
     "geom:bbox":"-81.328231,-6.371807,-79.210834,-4.081778",
     "geom:latitude":-5.132001,
     "geom:longitude":-80.334577,
@@ -342,17 +342,19 @@
         "gn:id":3693525,
         "gp:id":2346487,
         "hasc:id":"PE.PI",
+        "iso:code":"PE-PIU",
         "iso:id":"PE-PIU",
         "qs_pg:id":219590,
         "unlc:id":"PE-PIU",
         "wd:id":"Q208183",
         "wk:page":"Piura Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5bffe333468cf51b029b8a389c624c2c",
+    "wof:geomhash":"ac652820e5ffe8addde91ca358a01242",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -369,7 +371,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850385,
+    "wof:lastmodified":1695884858,
     "wof:name":"Piura",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/31/85675831.geojson
+++ b/data/856/758/31/85675831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.378393,
-    "geom:area_square_m":4668282721.808786,
+    "geom:area_square_m":4668282697.365142,
     "geom:bbox":"-81.041155,-4.231936,-80.126784,-3.397425",
     "geom:latitude":-3.856485,
     "geom:longitude":-80.544759,
@@ -332,17 +332,19 @@
         "gn:id":3691146,
         "gp:id":2346491,
         "hasc:id":"PE.TU",
+        "iso:code":"PE-TUM",
         "iso:id":"PE-TUM",
         "qs_pg:id":1083857,
         "unlc:id":"PE-TUM",
         "wd:id":"Q209597",
         "wk:page":"Tumbes Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"79d668ae73592bb808851ffe815b8fca",
+    "wof:geomhash":"bbf4cb423a199efa3e2502c9a3fe7410",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -359,7 +361,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850388,
+    "wof:lastmodified":1695884859,
     "wof:name":"Tumbes",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/35/85675835.geojson
+++ b/data/856/758/35/85675835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.765703,
-    "geom:area_square_m":21181732715.762581,
+    "geom:area_square_m":21181732716.24155,
     "geom:bbox":"-73.847748,-14.84283,-72.050994,-13.169617",
     "geom:latitude":-14.027893,
     "geom:longitude":-72.975402,
@@ -350,17 +350,19 @@
         "gn:id":3947421,
         "gp:id":2346470,
         "hasc:id":"PE.AP",
+        "iso:code":"PE-APU",
         "iso:id":"PE-APU",
         "qs_pg:id":890099,
         "unlc:id":"PE-APU",
         "wd:id":"Q208185",
         "wk:page":"Apur\u00edmac Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48ad83025966425352a50eb89252019a",
+    "wof:geomhash":"d0af0473c76b8cc22b7d8f4b1f9936c4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -377,7 +379,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850385,
+    "wof:lastmodified":1695884358,
     "wof:name":"Apurimac",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/39/85675839.geojson
+++ b/data/856/758/39/85675839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.334985,
-    "geom:area_square_m":63459199405.2892,
+    "geom:area_square_m":63459199323.586952,
     "geom:bbox":"-75.075086,-17.284939,-70.804084,-14.632807",
     "geom:latitude":-15.843414,
     "geom:longitude":-72.475096,
@@ -355,17 +355,19 @@
         "gn:id":3947319,
         "gp:id":2346471,
         "hasc:id":"PE.AR",
+        "iso:code":"PE-ARE",
         "iso:id":"PE-ARE",
         "qs_pg:id":1168708,
         "unlc:id":"PE-ARE",
         "wd:id":"Q205068",
         "wk:page":"Arequipa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5855570c82f1e44958bd30d8c5fe1032",
+    "wof:geomhash":"f6916b88e9b877ab94b85a3dbba2af44",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -382,7 +384,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850390,
+    "wof:lastmodified":1695884860,
     "wof:name":"Arequipa",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/43/85675843.geojson
+++ b/data/856/758/43/85675843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.003937,
-    "geom:area_square_m":72271407409.457657,
+    "geom:area_square_m":72271407378.022217,
     "geom:bbox":"-73.980361,-15.45866,-70.345047,-11.192943",
     "geom:latitude":-13.188923,
     "geom:longitude":-72.168904,
@@ -328,17 +328,19 @@
         "gn:id":3941583,
         "gp:id":2346475,
         "hasc:id":"PE.CS",
+        "iso:code":"PE-CUS",
         "iso:id":"PE-CUS",
         "qs_pg:id":913819,
         "unlc:id":"PE-CUS",
         "wd:id":"Q205057",
         "wk:page":"Cusco Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a51840adb83b1a800a6112e1d54a5a60",
+    "wof:geomhash":"31dd122acf16c5ac8e188a237869b7aa",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -355,7 +357,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850387,
+    "wof:lastmodified":1695884359,
     "wof:name":"Cusco",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/47/85675847.geojson
+++ b/data/856/758/47/85675847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.023317,
-    "geom:area_square_m":84947016119.03511,
+    "geom:area_square_m":84947009764.555969,
     "geom:bbox":"-72.428848,-13.341852,-68.652288,-9.906908",
     "geom:latitude":-11.981025,
     "geom:longitude":-70.534897,
@@ -338,17 +338,19 @@
         "gn:id":3935619,
         "gp:id":2346484,
         "hasc:id":"PE.MD",
+        "iso:code":"PE-MDD",
         "iso:id":"PE-MDD",
         "qs_pg:id":1222769,
         "unlc:id":"PE-MDD",
         "wd:id":"Q210896",
         "wk:page":"Madre de Dios Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0c4064e6b89292736dfce084bb07d7fc",
+    "wof:geomhash":"ebef95ffd92372373a316e14bb24810d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -365,7 +367,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850394,
+    "wof:lastmodified":1695884863,
     "wof:name":"Madre de Dios",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/57/85675857.geojson
+++ b/data/856/758/57/85675857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.335187,
-    "geom:area_square_m":15799772634.920725,
+    "geom:area_square_m":15799772722.433971,
     "geom:bbox":"-71.490983,-17.821566,-69.994758,-15.974455",
     "geom:latitude":-16.859932,
     "geom:longitude":-70.838533,
@@ -323,17 +323,19 @@
         "gn:id":3934607,
         "gp:id":2346485,
         "hasc:id":"PE.MQ",
+        "iso:code":"PE-MOQ",
         "iso:id":"PE-MOQ",
         "qs_pg:id":1222770,
         "unlc:id":"PE-MOQ",
         "wd:id":"Q208182",
         "wk:page":"Moquegua Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f786d7e4ea7c4c1cf3c2deb38d0ad419",
+    "wof:geomhash":"8589ce8b29205dd42b0d675cb472954d",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -350,7 +352,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850384,
+    "wof:lastmodified":1695884857,
     "wof:name":"Moquegua",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/61/85675861.geojson
+++ b/data/856/758/61/85675861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.35996,
-    "geom:area_square_m":16024765790.165619,
+    "geom:area_square_m":16024765078.478163,
     "geom:bbox":"-71.139086,-18.350929,-69.468157,-16.77041",
     "geom:latitude":-17.644465,
     "geom:longitude":-70.277526,
@@ -336,17 +336,19 @@
         "gn:id":3928127,
         "gp:id":2346490,
         "hasc:id":"PE.TA",
+        "iso:code":"PE-TAC",
         "iso:id":"PE-TAC",
         "qs_pg:id":423859,
         "unlc:id":"PE-TAC",
         "wd:id":"Q207413",
         "wk:page":"Tacna Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aa5ae38b9194bc97aef4136b4bb3cad3",
+    "wof:geomhash":"9a9fa20b1a7dd95fc38edecfa6b44933",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -363,7 +365,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850383,
+    "wof:lastmodified":1695885133,
     "wof:name":"Tacna",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/65/85675865.geojson
+++ b/data/856/758/65/85675865.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.954447,
-    "geom:area_square_m":36038839094.35273,
+    "geom:area_square_m":36038838804.84243,
     "geom:bbox":"-78.658481,-10.788775,-76.726387,-8.051141",
     "geom:latitude":-9.407851,
     "geom:longitude":-77.670199,
@@ -346,17 +346,19 @@
         "gn:id":3699674,
         "gp:id":2346469,
         "hasc:id":"PE.AN",
+        "iso:code":"PE-ANC",
         "iso:id":"PE-ANC",
         "qs_pg:id":890098,
         "unlc:id":"PE-ANC",
         "wd:id":"Q205089",
         "wk:page":"Ancash Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28b44340681fcec423ada59188bfe053",
+    "wof:geomhash":"aea1aec53143b8fa2456c229094e27a4",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -373,7 +375,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850389,
+    "wof:lastmodified":1695884359,
     "wof:name":"Ancash",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/71/85675871.geojson
+++ b/data/856/758/71/85675871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.69286,
-    "geom:area_square_m":33085289624.913651,
+    "geom:area_square_m":33085290145.724113,
     "geom:bbox":"-79.458443,-7.762836,-77.741707,-4.623749",
     "geom:latitude":-6.42861,
     "geom:longitude":-78.745823,
@@ -326,17 +326,19 @@
         "gn:id":3699087,
         "gp:id":2346473,
         "hasc:id":"PE.CJ",
+        "iso:code":"PE-CAJ",
         "iso:id":"PE-CAJ",
         "qs_pg:id":219584,
         "unlc:id":"PE-CAJ",
         "wd:id":"Q205078",
         "wk:page":"Cajamarca Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"05495b4da0f4757fec1e228bf4793f1f",
+    "wof:geomhash":"bc08551a45d13b6931939f2bf0ce03f6",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -353,7 +355,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850394,
+    "wof:lastmodified":1695884360,
     "wof:name":"Cajamarca",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/75/85675875.geojson
+++ b/data/856/758/75/85675875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.054759,
-    "geom:area_square_m":37261945154.558105,
+    "geom:area_square_m":37261944645.995796,
     "geom:bbox":"-77.316818,-10.489615,-74.510865,-8.314332",
     "geom:latitude":-9.41971,
     "geom:longitude":-76.038841,
@@ -342,16 +342,18 @@
         "gn:id":3696416,
         "gp:id":2346477,
         "hasc:id":"PE.HC",
+        "iso:code":"PE-HUC",
         "iso:id":"PE-HUC",
         "qs_pg:id":1135212,
         "unlc:id":"PE-HUC",
         "wd:id":"Q215221"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3b7e3e2737535ef7f5a12814f8c3f02e",
+    "wof:geomhash":"14ef4ebf2514e29463dfe0e819c0e535",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -368,7 +370,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850387,
+    "wof:lastmodified":1695884358,
     "wof:name":"Huanuco",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/79/85675879.geojson
+++ b/data/856/758/79/85675879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.068399,
-    "geom:area_square_m":25331466278.631588,
+    "geom:area_square_m":25331466844.089996,
     "geom:bbox":"-79.690151,-8.969465,-76.90184,-6.940957",
     "geom:latitude":-7.921637,
     "geom:longitude":-78.368161,
@@ -354,17 +354,19 @@
         "gn:id":3695781,
         "gp:id":2346480,
         "hasc:id":"PE.LL",
+        "iso:code":"PE-LAL",
         "iso:id":"PE-LAL",
         "qs_pg:id":423854,
         "unlc:id":"PE-LAL",
         "wd:id":"Q205126",
         "wk:page":"La Libertad Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4f8f962350c088f3ab3f3529e7c8598",
+    "wof:geomhash":"22877eae3d756ec667822186ff1f3c60",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -381,7 +383,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850392,
+    "wof:lastmodified":1695884861,
     "wof:name":"La Libertad",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/83/85675883.geojson
+++ b/data/856/758/83/85675883.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.990921,
-    "geom:area_square_m":24213475993.265049,
+    "geom:area_square_m":24213474887.838421,
     "geom:bbox":"-76.730492,-11.155084,-74.131943,-9.428311",
     "geom:latitude":-10.397582,
     "geom:longitude":-75.301176,
@@ -336,17 +336,19 @@
         "gn:id":3932834,
         "gp:id":2346486,
         "hasc:id":"PE.PA",
+        "iso:code":"PE-PAS",
         "iso:id":"PE-PAS",
         "qs_pg:id":219589,
         "unlc:id":"PE-PAS",
         "wd:id":"Q211208",
         "wk:page":"Pasco Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0da4ddd911f6d1a55bf6cdc271879a47",
+    "wof:geomhash":"f357006a6b86daa9dd564d79cfd5ce47",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -363,7 +365,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850392,
+    "wof:lastmodified":1695884862,
     "wof:name":"Pasco",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/85/85675885.geojson
+++ b/data/856/758/85/85675885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.845321,
-    "geom:area_square_m":71823606395.335129,
+    "geom:area_square_m":71823604913.393784,
     "geom:bbox":"-78.652535,-8.795639,-75.486701,-2.987278",
     "geom:latitude":-6.273143,
     "geom:longitude":-77.087981,
@@ -348,17 +348,19 @@
         "gn:id":3692385,
         "gp:id":2346489,
         "hasc:id":"PE.SM",
+        "iso:code":"PE-SAM",
         "iso:id":"PE-SAM",
         "qs_pg:id":423858,
         "unlc:id":"PE-SAM",
         "wd:id":"Q211793",
         "wk:page":"San Mart\u00edn Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"321420b5036ddf3d059e606d4f5ee8ee",
+    "wof:geomhash":"2baf1b38b73711e15990db5871a6cd80",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -375,7 +377,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850393,
+    "wof:lastmodified":1695884862,
     "wof:name":"San Martin",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/91/85675891.geojson
+++ b/data/856/758/91/85675891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.673487,
-    "geom:area_square_m":105725182484.819748,
+    "geom:area_square_m":105725181445.593079,
     "geom:bbox":"-75.945748,-11.448199,-70.493962,-7.294762",
     "geom:latitude":-9.621314,
     "geom:longitude":-73.434628,
@@ -343,17 +343,19 @@
         "gn:id":3691099,
         "gp:id":2346492,
         "hasc:id":"PE.UC",
+        "iso:code":"PE-UCA",
         "iso:id":"PE-UCA",
         "qs_pg:id":423860,
         "unlc:id":"PE-UCA",
         "wd:id":"Q207424",
         "wk:page":"Ucayali Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"f9b290ab7e091f352a47de31c55df3a4",
+    "wof:geomhash":"776ae155e696200a801fa8d78196fa7a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -370,7 +372,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850388,
+    "wof:lastmodified":1695884859,
     "wof:name":"Ucayali",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/95/85675895.geojson
+++ b/data/856/758/95/85675895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.517805,
-    "geom:area_square_m":18669418334.356953,
+    "geom:area_square_m":18669417875.369602,
     "geom:bbox":"-78.71067,-6.98658,-77.132844,-4.50077",
     "geom:latitude":-5.84173,
     "geom:longitude":-78.098058,
@@ -357,17 +357,19 @@
         "gn:id":3699699,
         "gp:id":2346468,
         "hasc:id":"PE.AM",
+        "iso:code":"PE-AMA",
         "iso:id":"PE-AMA",
         "qs_pg:id":890097,
         "unlc:id":"PE-AMA",
         "wd:id":"Q201162",
         "wk:page":"Amazonas Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e18f644baae044e8c9975ad98ae33ca1",
+    "wof:geomhash":"9e73bbf58f36246c0cc50e0f547ca338",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -384,7 +386,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850384,
+    "wof:lastmodified":1695884858,
     "wof:name":"Amazonas",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/758/99/85675899.geojson
+++ b/data/856/758/99/85675899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":30.579214,
-    "geom:area_square_m":376975747022.44696,
+    "geom:area_square_m":376975747506.651611,
     "geom:bbox":"-77.825742,-8.716139,-69.948846,-0.038777",
     "geom:latitude":-4.122139,
     "geom:longitude":-74.426853,
@@ -343,17 +343,19 @@
         "gn:id":3695238,
         "gp:id":2346483,
         "hasc:id":"PE.LO",
+        "iso:code":"PE-LOR",
         "iso:id":"PE-LOR",
         "qs_pg:id":219588,
         "unlc:id":"PE-LOR",
         "wd:id":"Q200938",
         "wk:page":"Loreto Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7b60c2872c1192f08b44a24ef4e0a55a",
+    "wof:geomhash":"d806fc3a4969bad78fc1a07bdcaa903b",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -370,7 +372,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850391,
+    "wof:lastmodified":1695884860,
     "wof:name":"Loreto",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/03/85675903.geojson
+++ b/data/856/759/03/85675903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.649328,
-    "geom:area_square_m":43762244355.148781,
+    "geom:area_square_m":43762243941.946373,
     "geom:bbox":"-75.138611,-15.629709,-72.846824,-12.167912",
     "geom:latitude":-14.090694,
     "geom:longitude":-74.083042,
@@ -347,17 +347,19 @@
         "gn:id":3947018,
         "gp:id":2346472,
         "hasc:id":"PE.AY",
+        "iso:code":"PE-AYA",
         "iso:id":"PE-AYA",
         "qs_pg:id":890100,
         "unlc:id":"PE-AYA",
         "wd:id":"Q205112",
         "wk:page":"Ayacucho Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a069eff224677c077a72520fe96bc8c8",
+    "wof:geomhash":"93b5571cb69eaf1b7c204371232488bb",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -374,7 +376,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850395,
+    "wof:lastmodified":1695884863,
     "wof:name":"Ayacucho",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/11/85675911.geojson
+++ b/data/856/759/11/85675911.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.839767,
-    "geom:area_square_m":22162938849.283382,
+    "geom:area_square_m":22162938849.282928,
     "geom:bbox":"-75.810516,-14.130258,-74.270713,-11.984594",
     "geom:latitude":-13.024188,
     "geom:longitude":-75.002937,
@@ -345,17 +345,19 @@
         "gn:id":3939467,
         "gp:id":2346476,
         "hasc:id":"PE.HV",
+        "iso:code":"PE-HUV",
         "iso:id":"PE-HUV",
         "qs_pg:id":219586,
         "unlc:id":"PE-HUV",
         "wd:id":"Q505220",
         "wk:page":"Huancavelica Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d295eea96ef2617c9886257f016859df",
+    "wof:geomhash":"4dac1e1ad2e7699226754ed688286060",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -372,7 +374,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850395,
+    "wof:lastmodified":1695884863,
     "wof:name":"Huancavelica",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/15/85675915.geojson
+++ b/data/856/759/15/85675915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.766435,
-    "geom:area_square_m":21170650730.389198,
+    "geom:area_square_m":21170652199.300667,
     "geom:bbox":"-76.398364,-15.442959,-74.647004,-12.964889",
     "geom:latitude":-14.234473,
     "geom:longitude":-75.573544,
@@ -340,17 +340,19 @@
         "gn:id":3938526,
         "gp:id":2346478,
         "hasc:id":"PE.IC",
+        "iso:code":"PE-ICA",
         "iso:id":"PE-ICA",
         "qs_pg:id":1168710,
         "unlc:id":"PE-ICA",
         "wd:id":"Q208186",
         "wk:page":"Ica Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"37b20dfc4b130464280224c18da657f3",
+    "wof:geomhash":"ed4bf40ba0314a5c7528c8fe2b1cd46a",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -367,7 +369,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850396,
+    "wof:lastmodified":1695884864,
     "wof:name":"Ica",
     "wof:parent_id":85632521,
     "wof:placetype":"region",

--- a/data/856/759/19/85675919.geojson
+++ b/data/856/759/19/85675919.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.670939,
-    "geom:area_square_m":44473625221.670052,
+    "geom:area_square_m":44473625820.971542,
     "geom:bbox":"-76.519227,-12.683607,-73.355408,-10.653096",
     "geom:latitude":-11.536981,
     "geom:longitude":-74.884936,
@@ -349,17 +349,19 @@
         "gn:id":3937485,
         "gp:id":2346479,
         "hasc:id":"PE.JU",
+        "iso:code":"PE-JUN",
         "iso:id":"PE-JUN",
         "qs_pg:id":219587,
         "unlc:id":"PE-JUN",
         "wd:id":"Q207973",
         "wk:page":"Jun\u00edn Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e4ee0bdf0d90e6a302de048d3451dd15",
+    "wof:geomhash":"ddf119f0c22f2659090f1a54b336602f",
     "wof:hierarchy":[
         {
             "continent_id":102191577,
@@ -376,7 +378,7 @@
         "spa",
         "que"
     ],
-    "wof:lastmodified":1690850396,
+    "wof:lastmodified":1695884360,
     "wof:name":"Junin",
     "wof:parent_id":85632521,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.